### PR TITLE
chore: Python 3.13/3.14 support, badges, CI improvements, agentic guidelines

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,38 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+    paths: [pyproject.toml]
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git tag ${{ steps.version.outputs.tag }}
+          git push origin ${{ steps.version.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,10 @@ jobs:
       - run: uv pip install -e ".[dev]"
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
-      - run: uv run pytest
+      - run: uv run pytest --cov=hotmem --cov-report=xml
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -22,3 +23,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ github.ref_name }} --generate-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,39 @@ HotMem is deliberately small. Before proposing a new feature, check that it alig
 
 If your idea requires adding heavy dependencies or external services, it may be a better fit for the broader KnowGuard ecosystem rather than HotMem core.
 
+## Agentic Contributors
+
+If you are a code agent (Copilot, Cursor, Oz, Claude Code, etc.), follow these rules on top of everything above.
+
+### Formatting
+
+- No em dashes. Use `--` or rephrase the sentence
+- No smart/curly quotes. ASCII only in code, comments, docstrings, and docs
+- No trailing whitespace or mixed indentation
+
+### Code Discipline
+
+- Do not add dependencies. HotMem is zero-dep core (stdlib + FastAPI/Click/httpx). If you think you need one, stop and ask
+- Do not create new files. HotMem is deliberately small. Extend existing modules unless explicitly told otherwise
+- Do not refactor module boundaries. Each module is self-contained by design
+- Every module must keep its docstring header (purpose, interface, deps, extension points)
+- Use `trace.py` for logging, never `print()` or stdlib `logging`
+- No `# type: ignore` or `# noqa` without an inline explanation
+
+### PR Discipline
+
+- No placeholder/TODO comments in submitted code
+- Every new behavior needs a test
+- Run the full suite before submitting: `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run pytest`
+- Conventional commit messages (`feat:`, `fix:`, `chore:`, `docs:`)
+- One concern per PR. Do not bundle unrelated changes
+
+### API Contract
+
+- Search always returns LLM-ready message objects. Do not break this contract
+- All endpoints live under `/v1`. Do not add routes outside this prefix
+- SQLite only. Do not introduce other storage backends
+
 ## Reporting Issues
 
 Use the [GitHub issue templates](https://github.com/KnowGuard-AI/HotMem/issues/new/choose) for bug reports and feature requests.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # HotMem
 
+[![CI](https://github.com/KnowGuard-AI/HotMem/actions/workflows/ci.yml/badge.svg)](https://github.com/KnowGuard-AI/HotMem/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/hotmem)](https://pypi.org/project/hotmem/)
+[![Python](https://img.shields.io/pypi/pyversions/hotmem)](https://pypi.org/project/hotmem/)
+[![codecov](https://codecov.io/gh/KnowGuard-AI/HotMem/branch/main/graph/badge.svg)](https://codecov.io/gh/KnowGuard-AI/HotMem)
+[![License: MIT](https://img.shields.io/github/license/KnowGuard-AI/HotMem)](LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
 A local-first memory sidecar for agent applications. One SQLite DB. One port: 8711.
 
 HotMem provides fast, queryable working memory with hybrid vector + keyword search. Store facts, retrieve them ranked, and get back LLM-ready message objects you can stitch directly into prompts.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,9 @@ HotMem provides fast, queryable working memory with hybrid vector + keyword sear
 ## Install
 
 ```bash
-pip install hotmem@git+https://github.com/KnowGuard-AI/HotMem.git
+pip install hotmem
 # or
-uv add hotmem@git+https://github.com/KnowGuard-AI/HotMem.git
-```
-
-Or add to `requirements.txt`:
-
-```
-hotmem @ git+https://github.com/KnowGuard-AI/HotMem.git
+uv pip install hotmem
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Repository = "https://github.com/KnowGuard-AI/HotMem"
 [project.optional-dependencies]
 dev = [
     "pytest>=9,<10",
+    "pytest-cov>=6,<7",
     "ruff>=0.15,<1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hotmem"
-version = "0.1.4"
+version = "0.1.5"
 description = "A local-first memory sidecar for agent applications"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## What changed

- Add Python 3.13 and 3.14 to classifiers and CI matrix
- Bump version to 0.1.5
- Update install instructions to use PyPI (`pip install hotmem`)
- Add auto-tag workflow (tags on version bump merge to main)
- Add auto-release workflow (creates GitHub Release on tag push)
- Add README badges (CI, PyPI, Python versions, Codecov, License, Ruff)
- Add `pytest-cov` + Codecov coverage upload to CI (runs on 3.13 matrix leg)
- Add agentic contributor guidelines to CONTRIBUTING.md

## Details

### Python 3.13/3.14
- Added classifiers in `pyproject.toml`
- Extended CI matrix to test against 3.11, 3.12, 3.13, 3.14

### CI/CD
- `auto-tag.yml`: watches merges to main, creates a git tag when `pyproject.toml` version changes
- `release.yml`: creates a GitHub Release when a version tag is pushed
- CI now runs `pytest --cov=hotmem --cov-report=xml` and uploads to Codecov

### README badges
CI status, PyPI version, Python versions, Codecov coverage, MIT license, Ruff code style

### Agentic contributor guidelines
New section in `CONTRIBUTING.md` with rules for code agents:
- Formatting: no em dashes, ASCII only, no trailing whitespace
- Code discipline: no new deps, no new files, use trace.py, keep module docstrings
- PR discipline: tests required, run full suite, conventional commits
- API contract: LLM-ready messages, /v1 prefix, SQLite only

## Verification

```bash
uv run ruff check src/ tests/
uv run ruff format --check src/ tests/
uv run pytest
```

Co-Authored-By: Oz <oz-agent@warp.dev>