### PR TITLE
ci: fix release automation dispatch

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -9,6 +9,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@v4
@@ -36,3 +37,9 @@ jobs:
         run: |
           git tag ${{ steps.version.outputs.tag }}
           git push origin ${{ steps.version.outputs.tag }}
+
+      - name: Run release workflow
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml --ref main -f tag=${{ steps.version.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example v0.1.6"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -14,9 +20,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
 
       - name: Build
         run: uv build
@@ -27,4 +35,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --generate-notes
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 ||
+            gh release create "$RELEASE_TAG" --verify-tag --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,24 @@ jobs:
       - name: Build
         run: uv build
 
+      - name: Verify package metadata
+        run: |
+          uvx twine check dist/*
+          python - <<'PY'
+          import pathlib
+          import tarfile
+
+          readme = pathlib.Path("README.md").read_text()
+          sdist = next(pathlib.Path("dist").glob("*.tar.gz"))
+
+          with tarfile.open(sdist) as tar:
+              member = next(m for m in tar.getmembers() if m.name.endswith("/PKG-INFO"))
+              metadata = tar.extractfile(member).read().decode()
+
+          if readme.strip() not in metadata:
+              raise SystemExit("README.md was not embedded in package metadata")
+          PY
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A local-first memory sidecar for agent applications. One SQLite DB. One port: 87
 
 HotMem provides fast, queryable working memory with hybrid vector + keyword search. Store facts, retrieve them ranked, and get back LLM-ready message objects you can stitch directly into prompts.
 
+Supports Python 3.11, 3.12, 3.13, and 3.14.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## What
Fix release automation so future version bump merges do not depend on a tag push created by GITHUB_TOKEN to trigger a separate workflow.

Changes:
- Adds workflow_dispatch support to .github/workflows/release.yml with a required tag input.
- Checks out the requested release tag for manual dispatches and tag pushes.
- Upgrades astral-sh/setup-uv from v3 to v4 in the release workflow.
- Makes GitHub Release creation idempotent by skipping creation when the release already exists.
- Grants actions: write to auto-tag.yml and explicitly dispatches release.yml after creating a new tag.
- Updates README.md to explicitly list Python 3.11, 3.12, 3.13, and 3.14 support.
- Adds release-time package metadata verification: twine check plus an sdist PKG-INFO assertion that README.md is embedded as the PyPI long description.

Also completed the missing v0.1.5 GitHub Release manually from the existing tag: https://github.com/KnowGuard-AI/HotMem/releases/tag/v0.1.5

## Why
PR #19 merged on May 28, 2026 and Auto Tag did run, but it found v0.1.5 already existed and skipped tag creation. Since no new tag was pushed, release.yml did not run. There is also a future reliability issue: workflows triggered by GITHUB_TOKEN-created events may be suppressed by GitHub, so chaining release publication only from the auto-created tag push is brittle.

The current PyPI v0.1.5 page was built from the older v0.1.5 side tag, so its metadata can look stale. PyPI does not allow replacing already-published distribution files for the same version. This PR ensures the next release builds from the checked-out release tag and fails before upload if README.md is not included as the package long description.

## Verification
- [x] YAML parsed successfully with Ruby YAML loader
- [x] uv build completed locally
- [x] Verified README.md is embedded in sdist PKG-INFO
- [x] Confirmed v0.1.5 GitHub Release exists and is marked latest
- [x] Tests pass: /Users/zubinj/forge/.knwb/bin/pytest -> 33 passed in 0.84s on Python 3.13.5
- [x] Lint passes: /Users/zubinj/forge/.knwb/bin/ruff check src/ tests/ -> All checks passed
- [x] Format check passes: /Users/zubinj/forge/.knwb/bin/ruff format --check src/ tests/ -> 18 files already formatted
- [x] No new external dependencies added to core