### PR TITLE
feat: add per-memory TTL expiry

### DIFF
--- a/src/hotmem/client.py
+++ b/src/hotmem/client.py
@@ -44,6 +44,7 @@ class HotMemClient:
         source: str = "",
         importance: float = 0.5,
         metadata: dict[str, Any] | None = None,
+        ttl_seconds: int | None = None,
     ) -> dict[str, Any]:
         """Add a fact to memory."""
         payload = {
@@ -53,6 +54,8 @@ class HotMemClient:
             "importance": importance,
             "metadata": metadata or {},
         }
+        if ttl_seconds is not None:
+            payload["ttl_seconds"] = ttl_seconds
         resp = self._client.post("/v1/add", json=payload)
         resp.raise_for_status()
         return resp.json()

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -8,7 +8,6 @@ Purpose:
 Interface:
     MemoryDB(db_path: str | Path)
         .insert(id, identifier, fact_text, embedding_blob, ...) -> None
-        .search_all() -> list[Row]
         .count() -> int
         .all_rows() -> list[Row]
         .exists(content_hash: str) -> bool
@@ -43,6 +42,7 @@ CREATE TABLE IF NOT EXISTS memories (
     importance      REAL DEFAULT 0.5,
     metadata_json   TEXT DEFAULT '{{}}',
     content_hash    TEXT DEFAULT '',
+    ttl_seconds     INTEGER,
     created_at      TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
 CREATE INDEX IF NOT EXISTS idx_memories_identifier ON memories(identifier);
@@ -65,6 +65,11 @@ def _cosine_similarity(blob_a: bytes | None, blob_b: bytes | None) -> float | No
     return dot / (norm_a * norm_b)
 
 
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(row["name"] == column for row in rows)
+
+
 class MemoryDB:
     """SQLite-backed memory store with cosine similarity UDF."""
 
@@ -76,7 +81,15 @@ class MemoryDB:
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.create_function("cosine_sim", 2, _cosine_similarity)
         self._conn.executescript(_SCHEMA)
+        self._migrate()
         _trace.info("init", "database opened", detail={"path": self.db_path})
+
+    def _migrate(self) -> None:
+        """Apply additive schema updates for existing HotMem databases."""
+        if not _has_column(self._conn, "memories", "ttl_seconds"):
+            self._conn.execute("ALTER TABLE memories ADD COLUMN ttl_seconds INTEGER")
+            self._conn.commit()
+            _trace.info("migrate", "added ttl_seconds column")
 
     def insert(
         self,
@@ -91,13 +104,18 @@ class MemoryDB:
         importance: float = 0.5,
         metadata_json: str = "{}",
         content_hash: str = "",
+        ttl_seconds: int | None = None,
+        created_at: str | None = None,
     ) -> None:
         """Insert a memory row."""
         self._conn.execute(
             """INSERT OR REPLACE INTO memories
             (id, identifier, fact_text, embedding, embedding_dim, embedding_model,
-             source, importance, metadata_json, content_hash)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+             source, importance, metadata_json, content_hash, ttl_seconds, created_at)
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )""",
             (
                 id,
                 identifier,
@@ -109,6 +127,8 @@ class MemoryDB:
                 importance,
                 metadata_json,
                 content_hash,
+                ttl_seconds,
+                created_at,
             ),
         )
         self._conn.commit()
@@ -120,6 +140,8 @@ class MemoryDB:
             """SELECT id, identifier, fact_text, importance, metadata_json, source,
                       cosine_sim(embedding, ?) AS cosine_score
                FROM memories
+               WHERE ttl_seconds IS NULL
+                  OR (strftime('%s', 'now') - strftime('%s', created_at)) < ttl_seconds
                ORDER BY cosine_score DESC""",
             (query_embedding,),
         ).fetchall()
@@ -134,7 +156,7 @@ class MemoryDB:
         """Return all memory rows as dicts (for snapshot export)."""
         rows = self._conn.execute(
             """SELECT id, identifier, fact_text, embedding_dim, embedding_model,
-                      source, importance, metadata_json, content_hash, created_at
+                      source, importance, metadata_json, content_hash, ttl_seconds, created_at
                FROM memories"""
         ).fetchall()
         return [dict(r) for r in rows]

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -49,6 +49,7 @@ class AddRequest(BaseModel):
     source: str = ""
     importance: float = Field(default=0.5, ge=0.0, le=1.0)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    ttl_seconds: int | None = Field(default=None, ge=1)
 
 
 class SearchRequest(BaseModel):
@@ -164,6 +165,7 @@ def create_app(
                 importance=req.importance,
                 metadata_json=json.dumps(req.metadata),
                 content_hash=content_hash,
+                ttl_seconds=req.ttl_seconds,
             )
         return {
             "memory_id": memory_id,

--- a/src/hotmem/swap.py
+++ b/src/hotmem/swap.py
@@ -91,6 +91,8 @@ def hydrate(db: MemoryDB, swap_path: str | Path) -> HydrateResult:
                     importance=record.get("importance", 0.5),
                     metadata_json=json.dumps(record.get("metadata", {})),
                     content_hash=content_hash,
+                    ttl_seconds=record.get("ttl_seconds"),
+                    created_at=record.get("created_at"),
                 )
                 loaded += 1
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,6 +44,21 @@ def test_add_memory(client: TestClient):
     assert "trace_ms" in data
 
 
+def test_add_memory_with_ttl(client: TestClient):
+    resp = client.post(
+        "/v1/add",
+        json={
+            "identifier": "vendor_x",
+            "fact": "Temporary invoice note",
+            "ttl_seconds": 3600,
+        },
+    )
+    assert resp.status_code == 200
+
+    search = client.post("/v1/search", json={"query": "temporary invoice note"}).json()
+    assert search["count"] == 1
+
+
 def test_add_and_search(client: TestClient):
     # Add some facts
     client.post("/v1/add", json={"identifier": "a", "fact": "duplicate invoice risk for vendor x"})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,6 +33,14 @@ def test_add_and_search(mock_client: HotMemClient):
     assert "score" in memories[0]
 
 
+def test_add_with_ttl(mock_client: HotMemClient):
+    result = mock_client.add("vendor_a", "temporary client fact", ttl_seconds=3600)
+    assert "memory_id" in result
+
+    memories = mock_client.search("temporary client fact", top_k=1)
+    assert len(memories) == 1
+
+
 def test_health(mock_client: HotMemClient):
     data = mock_client.health()
     assert data["status"] == "ok"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 from hotmem.db import MemoryDB
 from hotmem.embed import embed_text, pack_embedding
 
@@ -51,3 +53,48 @@ def test_all_rows(tmp_db: MemoryDB):
     rows = tmp_db.all_rows()
     assert len(rows) == 1
     assert rows[0]["id"] == "r1"
+    assert rows[0]["ttl_seconds"] is None
+
+
+def test_insert_with_ttl(tmp_db: MemoryDB):
+    vec = embed_text("temporary fact")
+    blob = pack_embedding(vec)
+    tmp_db.insert(
+        id="ttl1",
+        identifier="x",
+        fact_text="temporary fact",
+        embedding=blob,
+        ttl_seconds=3600,
+    )
+
+    row = tmp_db.all_rows()[0]
+    assert row["ttl_seconds"] == 3600
+
+
+def test_existing_db_gets_ttl_column(tmp_path):
+    db_path = tmp_path / "old.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE memories (
+            id TEXT PRIMARY KEY,
+            identifier TEXT NOT NULL,
+            fact_text TEXT NOT NULL,
+            embedding BLOB,
+            embedding_dim INTEGER,
+            embedding_model TEXT DEFAULT '',
+            source TEXT DEFAULT '',
+            importance REAL DEFAULT 0.5,
+            metadata_json TEXT DEFAULT '{}',
+            content_hash TEXT DEFAULT '',
+            created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+    db = MemoryDB(db_path)
+    try:
+        columns = {row["name"] for row in db._conn.execute("PRAGMA table_info(memories)")}
+        assert "ttl_seconds" in columns
+    finally:
+        db.close()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -50,3 +50,21 @@ def test_search_ranking_uses_importance(tmp_db: MemoryDB):
 def test_search_empty_db(tmp_db: MemoryDB):
     results = search_memories(tmp_db, "anything", top_k=5)
     assert results == []
+
+
+def test_search_filters_expired_memories(tmp_db: MemoryDB):
+    _add_fact(tmp_db, "permanent", "invoice memory permanent")
+    vec = embed_text("invoice memory expired")
+    blob = pack_embedding(vec)
+    tmp_db.insert(
+        id="expired",
+        identifier="test",
+        fact_text="invoice memory expired",
+        embedding=blob,
+        ttl_seconds=1,
+        created_at="2000-01-01T00:00:00Z",
+    )
+
+    results = search_memories(tmp_db, "invoice memory", top_k=5)
+
+    assert [r["memory_id"] for r in results] == ["permanent"]

--- a/tests/test_swap.py
+++ b/tests/test_swap.py
@@ -64,3 +64,25 @@ def test_snapshot_roundtrip(tmp_db: MemoryDB, tmp_path: Path):
     assert len(lines) == 1
     data = json.loads(lines[0])
     assert data["fact_text"] == "test fact"
+
+
+def test_snapshot_hydrate_preserves_ttl_and_created_at(tmp_db: MemoryDB, tmp_path: Path):
+    swap = tmp_path / "ttl_swap.jsonl"
+    record = {
+        "id": "ttl-swap",
+        "identifier": "swap",
+        "fact_text": "ttl fact",
+        "ttl_seconds": 3600,
+        "created_at": "2026-05-31T00:00:00Z",
+    }
+    swap.write_text(json.dumps(record) + "\n")
+
+    result = hydrate(tmp_db, swap)
+    assert result.loaded == 1
+
+    out = tmp_path / "out.jsonl"
+    snapshot(tmp_db, out)
+    data = json.loads(out.read_text().strip())
+
+    assert data["ttl_seconds"] == 3600
+    assert data["created_at"] == "2026-05-31T00:00:00Z"


### PR DESCRIPTION
## What
Add optional per-memory TTL support.

Changes:
- Adds nullable ttl_seconds storage to the memories schema.
- Migrates existing SQLite databases with ALTER TABLE ADD COLUMN when ttl_seconds is missing.
- Filters expired memories out of search_with_cosine at query time.
- Adds optional ttl_seconds to POST /v1/add and the Python HotMemClient.add() helper.
- Preserves ttl_seconds and created_at through hydrate/snapshot round trips.
- Adds coverage for DB migration, insertion, API/client add, search filtering, and swap preservation.

Closes #7

## Why
Basic expiry keeps temporary memory from resurfacing forever while staying intentionally simple: no background jobs, no garbage collection, no decay scoring, and no API response shape changes.

## Verification
- [x] Tests pass: PYTHONPATH=src /Users/zubinj/forge/.knwb/bin/pytest -> 39 passed in 0.63s on Python 3.13.5
- [x] Lint passes: /Users/zubinj/forge/.knwb/bin/ruff check src/ tests/ -> All checks passed
- [x] Format check passes: /Users/zubinj/forge/.knwb/bin/ruff format --check src/ tests/ -> 18 files already formatted
- [x] No new external dependencies added to core