### PR TITLE
feat: ecosystem expansion — TS client, framework adapters, Hermes provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,46 @@ jobs:
         with:
           files: coverage.xml
           fail_ci_if_error: false
+
+  adapters:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v4
+      - run: uv venv
+      - run: uv pip install -e ".[dev,mcp]"
+      - name: Install adapters
+        run: |
+          uv pip install -e adapters/langchain
+          uv pip install -e adapters/crewai
+          uv pip install -e adapters/autogen
+          uv pip install -e adapters/pydanticai
+          uv pip install -e adapters/hermes
+      - name: Lint adapters
+        run: uv run ruff check adapters/
+      - name: Test adapters
+        run: uv run pytest adapters/
+
+  typescript:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["18", "20"]
+    defaults:
+      run:
+        working-directory: ts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ with HotMemClient("http://127.0.0.1:8711") as client:
     messages = memories + [{"role": "user", "content": "Analyze this vendor."}]
 ```
 
+## Ecosystem
+
+HotMem core stays zero-dep. Framework adapters live in `adapters/`, each a separate
+pip-installable package wrapping `HotMemClient`:
+
+| Package | Framework |
+| --- | --- |
+| `hotmem-langchain` | LangChain (`BaseChatMessageHistory`, `BaseRetriever`) |
+| `hotmem-crewai` | CrewAI memory backend |
+| `hotmem-autogen` | AutoGen memory plugin |
+| `hotmem-pydanticai` | Pydantic AI dependency + tools |
+| `hotmem-hermes` | [Hermes Agent](https://github.com/NousResearch/hermes-agent) memory provider plugin |
+
+The `hotmem-hermes` adapter is the deep integration: HotMem implements the Hermes
+[Memory Provider Plugin](https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin)
+interface, so Hermes calls into HotMem at every lifecycle point automatically
+(prefetch, sync, memory-write mirroring, pre-compress extraction, session-end snapshot).
+
+A typed TypeScript client (`npm install hotmem`) lives in `ts/` — zero-dependency,
+works in Node 18+, Deno, Bun, and edge runtimes.
+
 ## Mounting
 
 Any directory can be a HotMem mount. The mount contains:

--- a/adapters/autogen/README.md
+++ b/adapters/autogen/README.md
@@ -1,0 +1,40 @@
+# hotmem-autogen
+
+AutoGen memory adapter for the [HotMem](https://github.com/KnowGuard-AI/HotMem) memory sidecar.
+
+## Install
+
+```sh
+pip install hotmem-autogen
+# with AutoGen itself:
+pip install "hotmem-autogen[autogen]"
+```
+
+## Quickstart
+
+```sh
+hotmem serve
+```
+
+```python
+from hotmem_autogen import HotMemMemoryPlugin
+
+memory = HotMemMemoryPlugin(identifier="my-agent", top_k=5)
+memory.save("Server staging runs on port 2222", importance=0.8)
+
+# Inject recall into agent context
+context = memory.add_context("staging server port")
+# "Relevant memories:\n- Server staging runs on port 2222"
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `add_context(query)` / `update_context(query)` | Return recalled memories as a context string |
+| `save(content, identifier, importance, metadata)` | Persist a fact |
+| `search(query, top_k)` | Hybrid-ranked search |
+
+## License
+
+MIT

--- a/adapters/autogen/hotmem_autogen/__init__.py
+++ b/adapters/autogen/hotmem_autogen/__init__.py
@@ -1,0 +1,9 @@
+"""HotMem AutoGen adapter.
+
+Exposes HotMem as an AutoGen-compatible memory store.
+"""
+
+from hotmem_autogen.memory import HotMemMemoryPlugin
+
+__all__ = ["HotMemMemoryPlugin"]
+__version__ = "0.1.0"

--- a/adapters/autogen/hotmem_autogen/memory.py
+++ b/adapters/autogen/hotmem_autogen/memory.py
@@ -1,0 +1,68 @@
+"""AutoGen memory plugin backed by HotMem.
+
+Compatible with AutoGen 0.4+ memory conventions: a memory store exposes
+add_context()/update_context() to inject recalled context and save messages.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hotmem.client import HotMemClient
+
+
+class HotMemMemoryPlugin:
+    """Memory plugin for AutoGen agents backed by HotMem.
+
+    Usage: attach to a ConversableAgent and register its hooks so recall
+    is injected before each turn and turns are persisted after.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://127.0.0.1:8711",
+        identifier: str = "autogen",
+        top_k: int = 5,
+        client: HotMemClient | None = None,
+    ) -> None:
+        self._client = client or HotMemClient(base_url)
+        self.identifier = identifier
+        self.top_k = top_k
+
+    @property
+    def client(self) -> HotMemClient:
+        return self._client
+
+    def add_context(self, query: str) -> str:
+        """Return recalled memories as a context string for the agent."""
+        memories = self._client.search(query, top_k=self.top_k)
+        if not memories:
+            return ""
+        lines = [f"- {m['content']}" for m in memories]
+        return "Relevant memories:\n" + "\n".join(lines)
+
+    def update_context(self, query: str) -> str:
+        """Alias for add_context."""
+        return self.add_context(query)
+
+    def save(
+        self,
+        content: str,
+        *,
+        identifier: str | None = None,
+        importance: float = 0.5,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Persist a fact to HotMem."""
+        return self._client.add(
+            identifier=identifier or self.identifier,
+            fact=content,
+            source="autogen",
+            importance=importance,
+            metadata=metadata or {},
+        )
+
+    def search(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        """Search memories."""
+        return self._client.search(query, top_k=top_k)

--- a/adapters/autogen/pyproject.toml
+++ b/adapters/autogen/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "hotmem-autogen"
+version = "0.1.0"
+description = "AutoGen memory adapter for the HotMem memory sidecar"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "valiantone", email = "zrjohn@yahoo.com" }]
+
+dependencies = [
+    "hotmem>=0.1.8",
+]
+
+[project.optional-dependencies]
+autogen = [
+    "autogen-agentchat>=0.4,<1",
+]
+dev = [
+    "pytest>=9,<10",
+    "ruff>=0.15,<1",
+]
+
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/adapters/autogen/tests/test_autogen.py
+++ b/adapters/autogen/tests/test_autogen.py
@@ -1,0 +1,55 @@
+"""Tests for hotmem_autogen."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from hotmem.server import create_app
+
+
+@pytest.fixture
+def hotmem_url(tmp_path: Path) -> str:
+    db_path = tmp_path / "autogen_test.sqlite"
+    app = create_app(db_path=db_path)
+    with TestClient(app) as transport:
+        yield transport
+
+
+def _make_client(hotmem_url):
+    from hotmem.client import HotMemClient
+
+    c = HotMemClient.__new__(HotMemClient)
+    c.base_url = "http://testserver"
+    c._client = hotmem_url
+    return c
+
+
+def test_add_context_returns_formatted(hotmem_url):
+    from hotmem_autogen import HotMemMemoryPlugin
+
+    plugin = HotMemMemoryPlugin(client=_make_client(hotmem_url), top_k=3)
+    plugin.save("Server staging runs on port 2222", importance=0.8)
+
+    ctx = plugin.add_context("staging server port")
+    assert "Relevant memories:" in ctx
+    assert "port 2222" in ctx
+
+
+def test_add_context_empty(hotmem_url):
+    from hotmem_autogen import HotMemMemoryPlugin
+
+    plugin = HotMemMemoryPlugin(client=_make_client(hotmem_url))
+    # empty store returns an empty context string
+    assert plugin.add_context("zzzznomatchquery12345") == ""
+
+
+def test_save_and_search(hotmem_url):
+    from hotmem_autogen import HotMemMemoryPlugin
+
+    plugin = HotMemMemoryPlugin(client=_make_client(hotmem_url))
+    plugin.save("user prefers concise answers", identifier="user", importance=0.9)
+
+    results = plugin.search("user preferences", top_k=5)
+    assert len(results) >= 1

--- a/adapters/crewai/README.md
+++ b/adapters/crewai/README.md
@@ -1,0 +1,37 @@
+# hotmem-crewai
+
+CrewAI memory adapter for the [HotMem](https://github.com/KnowGuard-AI/HotMem) memory sidecar.
+
+## Install
+
+```sh
+pip install hotmem-crewai
+```
+
+## Quickstart
+
+```sh
+hotmem serve
+```
+
+```python
+from hotmem_crewai import HotMemMemory
+
+memory = HotMemMemory()
+memory.save("Vendor Acme has NET-30 terms", identifier="vendor:acme", importance=0.8)
+
+results = memory.search("acme payment terms")
+# [{ "content": "Vendor Acme has NET-30 terms", "score": 0.91, ... }]
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `save(content, identifier, importance, metadata)` | Store a memory |
+| `search(query, top_k)` | Hybrid-ranked search |
+| `load(query, top_k)` | Alias for `search()` |
+
+## License
+
+MIT

--- a/adapters/crewai/hotmem_crewai/__init__.py
+++ b/adapters/crewai/hotmem_crewai/__init__.py
@@ -1,0 +1,9 @@
+"""HotMem CrewAI adapter.
+
+Exposes HotMem as a CrewAI-compatible memory store.
+"""
+
+from hotmem_crewai.memory import HotMemMemory
+
+__all__ = ["HotMemMemory"]
+__version__ = "0.1.0"

--- a/adapters/crewai/hotmem_crewai/memory.py
+++ b/adapters/crewai/hotmem_crewai/memory.py
@@ -1,0 +1,56 @@
+"""CrewAI memory backend backed by HotMem."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hotmem.client import HotMemClient
+
+
+class HotMemMemory:
+    """Memory store compatible with CrewAI's memory interface.
+
+    CrewAI memories expose save() and load()/search(). This adapter maps
+    them to HotMem add() and search().
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://127.0.0.1:8711",
+        client: HotMemClient | None = None,
+    ) -> None:
+        self._client = client or HotMemClient(base_url)
+
+    @property
+    def client(self) -> HotMemClient:
+        return self._client
+
+    def save(
+        self,
+        content: str,
+        *,
+        identifier: str = "crewai",
+        importance: float = 0.5,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Save a memory entry to HotMem."""
+        return self._client.add(
+            identifier=identifier,
+            fact=content,
+            source="crewai",
+            importance=importance,
+            metadata=metadata or {},
+        )
+
+    def search(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        """Search memories and return ranked results."""
+        return self._client.search(query, top_k=top_k)
+
+    def load(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        """Alias for search(), matching CrewAI's load convention."""
+        return self.search(query, top_k=top_k)
+
+    def clear(self) -> None:
+        """Clear memories. HotMem v0.1 has no delete; this is a no-op."""
+        pass

--- a/adapters/crewai/pyproject.toml
+++ b/adapters/crewai/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "hotmem-crewai"
+version = "0.1.0"
+description = "CrewAI memory adapter for the HotMem memory sidecar"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "valiantone", email = "zrjohn@yahoo.com" }]
+
+dependencies = [
+    "hotmem>=0.1.8",
+    "crewai>=0.70,<1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9,<10",
+    "ruff>=0.15,<1",
+]
+
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/adapters/crewai/tests/test_crewai.py
+++ b/adapters/crewai/tests/test_crewai.py
@@ -1,0 +1,47 @@
+"""Tests for hotmem_crewai."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from hotmem.server import create_app
+
+
+@pytest.fixture
+def hotmem_url(tmp_path: Path) -> str:
+    db_path = tmp_path / "crewai_test.sqlite"
+    app = create_app(db_path=db_path)
+    with TestClient(app) as transport:
+        yield transport
+
+
+def _make_client(hotmem_url):
+    from hotmem.client import HotMemClient
+
+    c = HotMemClient.__new__(HotMemClient)
+    c.base_url = "http://testserver"
+    c._client = hotmem_url
+    return c
+
+
+def test_save_and_search(hotmem_url):
+    from hotmem_crewai import HotMemMemory
+
+    mem = HotMemMemory(client=_make_client(hotmem_url))
+    mem.save("Vendor Acme has NET-30 terms", identifier="vendor:acme", importance=0.8)
+
+    results = mem.search("acme terms", top_k=5)
+    assert len(results) >= 1
+    assert "NET-30" in results[0]["content"]
+
+
+def test_load_alias(hotmem_url):
+    from hotmem_crewai import HotMemMemory
+
+    mem = HotMemMemory(client=_make_client(hotmem_url))
+    mem.save("prefers email updates", identifier="user")
+
+    loaded = mem.load("email", top_k=5)
+    assert len(loaded) >= 1

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,0 +1,59 @@
+# hotmem-hermes
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) memory provider plugin for the [HotMem](https://github.com/KnowGuard-AI/HotMem) local-first memory sidecar.
+
+Makes HotMem a first-class `memory.provider: hotmem` backend — Hermes calls into HotMem at every lifecycle point automatically (prefetch before each turn, sync after each turn, mirror built-in memory writes, pre-compress extraction, session-end snapshot).
+
+## Install
+
+```sh
+pip install hotmem-hermes
+```
+
+## Quickstart
+
+Start the HotMem sidecar and configure Hermes to use it:
+
+```sh
+hotmem serve  # start the sidecar on http://127.0.0.1:8711
+
+hermes memory setup        # select "hotmem"
+# or manually:
+hermes config set memory.provider hotmem
+```
+
+HotMem is local-first — no API key required. Configure the sidecar URL in `$HERMES_HOME/hotmem.json` or via the `HOTMEM_URL` env var.
+
+## How it works
+
+HotMem implements the Hermes [Memory Provider Plugin](https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin) interface:
+
+| Hermes hook | HotMem action |
+| --- | --- |
+| `prefetch(query)` | Vector + FTS5 recall injected before each LLM turn |
+| `sync_turn(user, assistant)` | Persist turns asynchronously (non-blocking) |
+| `on_memory_write(action, target, content)` | Mirror `MEMORY.md`/`USER.md` writes to HotMem (biased importance: user 0.9, memory 0.8) |
+| `on_pre_compress(messages)` | Extract durable facts before context compression |
+| `on_session_end(messages)` | Flush + snapshot to a profile-scoped swap file |
+| `hotmem_search` / `hotmem_store` tools | In-process tool routing to the sidecar |
+
+The built-in `MEMORY.md`/`USER.md` continues to work alongside HotMem — the provider is additive.
+
+## Bundled skill
+
+`hotmem-memory` (agentskills.io standard) teaches the agent when to persist learnings proactively. Install from the repo:
+
+```sh
+hermes skills install <this-repo>/adapters/hermes/skill/hotmem-memory
+```
+
+## CLI
+
+```sh
+hermes hotmem status   # sidecar health + memory count
+hermes hotmem config   # show active config
+```
+
+## License
+
+MIT

--- a/adapters/hermes/hotmem_hermes/__init__.py
+++ b/adapters/hermes/hotmem_hermes/__init__.py
@@ -1,0 +1,12 @@
+"""HotMem Hermes Agent adapter.
+
+Implements the Hermes Agent Memory Provider Plugin interface so HotMem
+becomes a first-class ``memory.provider: hotmem`` backend.
+
+See: https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin
+"""
+
+from hotmem_hermes.provider import HotMemMemoryProvider
+
+__all__ = ["HotMemMemoryProvider"]
+__version__ = "0.1.0"

--- a/adapters/hermes/hotmem_hermes/cli.py
+++ b/adapters/hermes/hotmem_hermes/cli.py
@@ -1,0 +1,58 @@
+"""Hermes CLI commands for the HotMem provider.
+
+Registered via ``register_cli(subparser)`` and gated to the active provider.
+Commands appear under ``hermes hotmem <subcommand>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from hotmem.client import HotMemClient
+
+
+def _status(args: argparse.Namespace) -> None:
+    hermes_home = args.hermes_home or Path.home() / ".hermes"
+    config_path = Path(hermes_home) / "hotmem.json"
+    config = json.loads(config_path.read_text()) if config_path.exists() else {}
+    base_url = config.get("hotmem_url", "http://127.0.0.1:8711")
+    client = HotMemClient(base_url)
+    try:
+        health = client.health()
+        print(f"HotMem sidecar: {health['status']}")
+        print(f"Memory count:  {health['memory_count']}")
+        print(f"Uptime:        {health['uptime_s']}s")
+        print(f"DB path:       {health['db_path']}")
+    except Exception as err:
+        print(f"HotMem sidecar unreachable at {base_url}: {err}")
+
+
+def _config(args: argparse.Namespace) -> None:
+    hermes_home = args.hermes_home or Path.home() / ".hermes"
+    config_path = Path(hermes_home) / "hotmem.json"
+    if config_path.exists():
+        print(config_path.read_text())
+    else:
+        print(f"No config at {config_path} — run `hermes memory setup`.")
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    """Build the ``hermes hotmem`` argparse tree."""
+    subs = subparser.add_subparsers(dest="hotmem_command")
+    p_status = subs.add_parser("status", help="Show HotMem sidecar health")
+    p_status.add_argument("--hermes-home", default=None)
+    p_config = subs.add_parser("config", help="Show active HotMem config")
+    p_config.add_argument("--hermes-home", default=None)
+    subparser.set_defaults(func=_dispatch)
+
+
+def _dispatch(args: argparse.Namespace) -> None:
+    cmd = getattr(args, "hotmem_command", None)
+    if cmd == "status":
+        _status(args)
+    elif cmd == "config":
+        _config(args)
+    else:
+        print("Usage: hermes hotmem <status|config>")

--- a/adapters/hermes/hotmem_hermes/plugin.yaml
+++ b/adapters/hermes/hotmem_hermes/plugin.yaml
@@ -1,0 +1,9 @@
+name: hotmem
+version: 0.1.0
+description: "Local-first HotMem memory sidecar as a Hermes memory provider."
+hooks:
+  - prefetch
+  - sync_turn
+  - on_memory_write
+  - on_pre_compress
+  - on_session_end

--- a/adapters/hermes/hotmem_hermes/provider.py
+++ b/adapters/hermes/hotmem_hermes/provider.py
@@ -1,0 +1,262 @@
+"""HotMem Hermes Agent memory provider plugin.
+
+Implements the Hermes Agent MemoryProvider ABC so HotMem runs as a
+``memory.provider: hotmem`` backend alongside the built-in MEMORY.md/USER.md.
+
+Hermes lifecycle hooks wired here:
+    - prefetch(query)            -> ranked recall before each LLM turn
+    - sync_turn(user, assistant) -> persist turns (async, non-blocking)
+    - system_prompt_block()       -> static header
+    - shutdown()                 -> close the client
+
+Sync-layer hooks (on_memory_write, on_pre_compress, on_session_end) live in
+``hotmem_hermes.sync`` and are composed by ``register()``.
+
+Reference:
+    https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from hotmem.client import AsyncHotMemClient
+
+try:
+    # When loaded inside a Hermes install, use the real ABC.
+    from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - exercised only outside Hermes
+
+    class MemoryProvider:  # type: ignore[no-redef]
+        """Local fallback mirroring the Hermes MemoryProvider contract."""
+
+        name: str = ""
+
+        def is_available(self) -> bool:
+            raise NotImplementedError
+
+        def initialize(self, session_id: str, **kwargs: Any) -> None:
+            raise NotImplementedError
+
+        def get_tool_schemas(self) -> list[dict[str, Any]]:
+            raise NotImplementedError
+
+        def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs: Any) -> Any:
+            raise NotImplementedError
+
+        def get_config_schema(self) -> list[dict[str, Any]]:
+            return []
+
+        def save_config(self, values: dict[str, Any], hermes_home: str) -> None:
+            pass
+
+        def system_prompt_block(self) -> str:
+            return ""
+
+        def prefetch(self, query: str, *, session_id: str = "") -> str:
+            return ""
+
+        def sync_turn(
+            self,
+            user_content: str,
+            assistant_content: str,
+            *,
+            session_id: str = "",
+            messages: list[Any] | None = None,
+        ) -> None:
+            pass
+
+        def shutdown(self) -> None:
+            pass
+
+
+_SEARCH_TOOL: dict[str, Any] = {
+    "name": "hotmem_search",
+    "description": "Search HotMem and return ranked, LLM-ready memories.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "top_k": {"type": "integer", "minimum": 1, "maximum": 100},
+            "max_chars": {"type": "integer", "minimum": 1},
+        },
+        "required": ["query"],
+    },
+}
+
+_STORE_TOOL: dict[str, Any] = {
+    "name": "hotmem_store",
+    "description": "Store a fact in HotMem memory.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "identifier": {"type": "string"},
+            "fact": {"type": "string"},
+            "importance": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            "ttl_seconds": {"type": "integer", "minimum": 1},
+        },
+        "required": ["identifier", "fact"],
+    },
+}
+
+
+class HotMemMemoryProvider(MemoryProvider):
+    """Hermes memory provider backed by a local HotMem sidecar."""
+
+    def __init__(self) -> None:
+        self._client: AsyncHotMemClient | None = None
+        self._session_id: str = ""
+        self._hermes_home: str = ""
+        self._base_url: str = "http://127.0.0.1:8711"
+        self._swap_path: str | None = None
+        self._sync_thread: threading.Thread | None = None
+
+    @property
+    def name(self) -> str:
+        return "hotmem"
+
+    def is_available(self) -> bool:
+        """Activate when a HotMem URL is configured. No network calls."""
+        url = os.environ.get("HOTMEM_URL")
+        if url:
+            return True
+        if self._hermes_home:
+            return (Path(self._hermes_home) / "hotmem.json").exists()
+        return False
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        hermes_home = kwargs.get("hermes_home", "")
+        self._session_id = session_id
+        self._hermes_home = hermes_home
+
+        config = self._load_config(hermes_home)
+        self._base_url = os.environ.get("HOTMEM_URL") or config.get(
+            "hotmem_url", "http://127.0.0.1:8711"
+        )
+        self._swap_path = config.get("swap_path") or (
+            str(Path(hermes_home) / "hotmem-swap.jsonl") if hermes_home else None
+        )
+        self._client = AsyncHotMemClient(self._base_url)
+
+    def _load_config(self, hermes_home: str) -> dict[str, Any]:
+        if not hermes_home:
+            return {}
+        path = Path(hermes_home) / "hotmem.json"
+        if path.exists():
+            return json.loads(path.read_text())
+        return {}
+
+    def get_config_schema(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "hotmem_url",
+                "description": "HotMem sidecar URL",
+                "default": "http://127.0.0.1:8711",
+            },
+            {
+                "key": "swap_path",
+                "description": "Profile-scoped swap file for snapshot/hydrate",
+                "default": "",
+            },
+        ]
+
+    def save_config(self, values: dict[str, Any], hermes_home: str) -> None:
+        Path(hermes_home).mkdir(parents=True, exist_ok=True)
+        path = Path(hermes_home) / "hotmem.json"
+        path.write_text(json.dumps(values, indent=2))
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return [_SEARCH_TOOL, _STORE_TOOL]
+
+    async def handle_tool_call(
+        self, tool_name: str, args: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        assert self._client is not None
+        if tool_name == "hotmem_search":
+            memories = await self._client.search(
+                args["query"],
+                top_k=args.get("top_k", 5),
+                max_chars=args.get("max_chars"),
+            )
+            return {"memories": memories, "count": len(memories)}
+        if tool_name == "hotmem_store":
+            result = await self._client.add(
+                args["identifier"],
+                args["fact"],
+                importance=args.get("importance", 0.5),
+                ttl_seconds=args.get("ttl_seconds"),
+            )
+            return result
+        raise ValueError(f"unknown tool: {tool_name}")
+
+    def system_prompt_block(self) -> str:
+        return "HotMem memory provider active — recall injected before each turn."
+
+    async def prefetch(self, query: str, *, session_id: str = "") -> str:
+        assert self._client is not None
+        memories = await self._client.search(query, top_k=5)
+        if not memories:
+            return ""
+        lines = [f"- {m['content']}" for m in memories]
+        return "HotMem recall:\n" + "\n".join(lines)
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: list[Any] | None = None,
+    ) -> None:
+        """Persist a turn asynchronously (non-blocking, per threading contract)."""
+        sid = session_id or self._session_id or "hermes"
+
+        def _sync() -> None:
+            import asyncio
+
+            async def _go() -> None:
+                assert self._client is not None
+                await self._client.add(
+                    sid,
+                    f"User: {user_content}",
+                    source="hermes:turn",
+                    importance=0.4,
+                    metadata={"role": "user", "session": sid},
+                )
+                await self._client.add(
+                    sid,
+                    f"Assistant: {assistant_content}",
+                    source="hermes:turn",
+                    importance=0.3,
+                    metadata={"role": "assistant", "session": sid},
+                )
+
+            with suppress(Exception):
+                asyncio.run(_go())
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(target=_sync, daemon=True)
+        self._sync_thread.start()
+
+    def shutdown(self) -> None:
+        import asyncio
+
+        if self._client is not None:
+            with suppress(Exception):
+                asyncio.run(self._client.close())
+            self._client = None
+
+
+def register(ctx: Any) -> None:
+    """Plugin entry point called by Hermes memory plugin discovery."""
+    provider = HotMemMemoryProvider()
+    from hotmem_hermes.sync import attach_sync
+
+    attach_sync(provider)
+    ctx.register_memory_provider(provider)

--- a/adapters/hermes/hotmem_hermes/sync.py
+++ b/adapters/hermes/hotmem_hermes/sync.py
@@ -1,0 +1,143 @@
+"""Hermes <-> HotMem deep memory sync.
+
+Wires the Hermes lifecycle hooks the base provider leaves as no-ops into a
+two-way memory bridge:
+
+    on_memory_write(action, target, content) -> mirror MEMORY.md/USER.md to HotMem
+    on_pre_compress(messages)               -> extract durable facts before discard
+    on_session_end(messages)               -> flush + snapshot to a swap file
+
+All hooks run through the provider's AsyncHotMemClient and are non-blocking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import re
+import threading
+from typing import Any
+
+# Importance biasing: user-profile facts surface first in recall.
+_IMPORTANCE = {"user": 0.9, "memory": 0.8}
+_IDENTIFIER = {"user": "hermes:user", "memory": "hermes:memory"}
+
+# Heuristic markers that a turn contains a durable fact worth persisting.
+_DURABLE_PATTERNS = re.compile(
+    r"\b(actually|remember that|from now on|don'?t|always|never|prefer)\b",
+    re.IGNORECASE,
+)
+
+
+class HotMemSync:
+    """Composable sync hooks for HotMemMemoryProvider."""
+
+    def __init__(self, provider: Any) -> None:
+        self._provider = provider
+        self._thread: threading.Thread | None = None
+
+    def _run(self, coro_factory: Any) -> None:
+        """Run an async coroutine in a daemon thread (non-blocking)."""
+
+        def _work() -> None:
+            with contextlib.suppress(Exception):
+                asyncio.run(coro_factory())
+
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+        self._thread = threading.Thread(target=_work, daemon=True)
+        self._provider._sync_thread = self._thread  # noqa: SLF001
+        self._thread.start()
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        **kwargs: Any,
+    ) -> None:
+        """Mirror a built-in MEMORY.md/USER.md write to HotMem.
+
+        Biased importance: user-profile facts (0.9) rank above env facts (0.8).
+        HotMem dedupes via content-hash, so ``replace`` is just a re-add.
+        ``remove`` best-effort sets a short TTL (HotMem has no delete in v0.1).
+        """
+        identifier = _IDENTIFIER.get(target, f"hermes:{target}")
+        importance = _IMPORTANCE.get(target, 0.5)
+        client = self._provider._client  # noqa: SLF001
+
+        async def _go() -> None:
+            if action == "remove":
+                await client.add(
+                    identifier,
+                    content,
+                    importance=importance,
+                    ttl_seconds=1,
+                    metadata={"action": "removed"},
+                )
+                return
+            await client.add(
+                identifier,
+                content,
+                source="hermes:memory_write",
+                importance=importance,
+                metadata={"target": target, "action": action},
+            )
+
+        self._run(_go)
+
+    def on_pre_compress(self, messages: list[Any], **kwargs: Any) -> None:
+        """Extract durable-looking facts from trailing context before compression.
+
+        Heuristic only — no LLM call. Defers richer extraction to a later issue.
+        """
+        client = self._provider._client  # noqa: SLF001
+        trailing = messages[-6:] if len(messages) > 6 else messages
+
+        async def _go() -> None:
+            for msg in trailing:
+                text = _msg_text(msg)
+                if not text or not _DURABLE_PATTERNS.search(text):
+                    continue
+                await client.add(
+                    "hermes:context",
+                    text[:1000],
+                    source="hermes:pre_compress",
+                    importance=0.6,
+                    metadata={"phase": "pre_compress"},
+                )
+
+        self._run(_go)
+
+    def on_session_end(self, messages: list[Any], **kwargs: Any) -> None:
+        """Flush and snapshot to a profile-scoped swap file for instant hydrate."""
+        client = self._provider._client  # noqa: SLF001
+        swap_path = self._provider._swap_path  # noqa: SLF001
+
+        async def _go() -> None:
+            if swap_path:
+                await client.snapshot(file=swap_path)
+
+        self._run(_go)
+
+
+def _msg_text(msg: Any) -> str:
+    """Best-effort text extraction from an OpenAI-style message."""
+    if isinstance(msg, str):
+        return msg
+    if isinstance(msg, dict):
+        return msg.get("content", "") or ""
+    return getattr(msg, "content", "") or ""
+
+
+def attach_sync(provider: Any) -> HotMemSync:
+    """Compose the sync hooks onto a provider instance.
+
+    Called by ``register()`` so the provider gains on_memory_write /
+    on_pre_compress / on_session_end without subclassing.
+    """
+    sync = HotMemSync(provider)
+    provider.on_memory_write = sync.on_memory_write  # type: ignore[attr-defined]
+    provider.on_pre_compress = sync.on_pre_compress  # type: ignore[attr-defined]
+    provider.on_session_end = sync.on_session_end  # type: ignore[attr-defined]
+    return sync

--- a/adapters/hermes/pyproject.toml
+++ b/adapters/hermes/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "hotmem-hermes"
+version = "0.1.0"
+description = "Hermes Agent memory provider plugin for the HotMem memory sidecar"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "valiantone", email = "zrjohn@yahoo.com" }]
+
+dependencies = [
+    "hotmem>=0.1.8",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9,<10",
+    "ruff>=0.15,<1",
+]
+
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["hotmem_hermes*"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/adapters/hermes/skill/hotmem-memory/SKILL.md
+++ b/adapters/hermes/skill/hotmem-memory/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: hotmem-memory
+description: Persist durable learnings to HotMem so they survive across sessions
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [memory, hotmem]
+    requires_toolsets: []
+---
+# HotMem Memory Persistence
+
+## When to Use
+After learning a durable fact, convention, or correction that should outlive this session.
+
+## Procedure
+1. Call `hotmem_store` with `identifier="hermes:learned"`, the fact, and importance (0.7 default, 0.9 for user preferences)
+2. For environment facts, use `identifier="hermes:memory"`
+3. For user preferences, use `identifier="hermes:user"`
+
+## Pitfalls
+- Do not store ephemeral session state (file paths, debug context)
+- Do not duplicate what is already in MEMORY.md — HotMem mirrors those automatically

--- a/adapters/hermes/tests/test_hermes.py
+++ b/adapters/hermes/tests/test_hermes.py
@@ -1,0 +1,225 @@
+"""Tests for hotmem_hermes — provider lifecycle, tools, sync, round-trip."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from hotmem.server import create_app
+
+
+@pytest.fixture
+def hotmem_app(tmp_path: Path):
+    """A running in-process HotMem server."""
+    db_path = tmp_path / "hermes_test.sqlite"
+    swap_path = tmp_path / "swap.jsonl"
+    app = create_app(db_path=db_path, swap_path=str(swap_path))
+    with TestClient(app) as transport:
+        yield transport, swap_path
+
+
+def _make_async_client(hotmem_app):
+    import httpx
+    from hotmem.client import AsyncHotMemClient
+
+    transport, _ = hotmem_app
+    client = AsyncHotMemClient.__new__(AsyncHotMemClient)
+    client.base_url = "http://testserver"
+    client._client = httpx.AsyncClient(
+        base_url=client.base_url,
+        transport=httpx.ASGITransport(app=transport.app),
+    )
+    return client
+
+
+def test_provider_name_and_config_schema():
+    from hotmem_hermes import HotMemMemoryProvider
+
+    p = HotMemMemoryProvider()
+    assert p.name == "hotmem"
+    schema = p.get_config_schema()
+    keys = [f["key"] for f in schema]
+    assert "hotmem_url" in keys
+
+
+def test_is_available_with_env(monkeypatch):
+    from hotmem_hermes import HotMemMemoryProvider
+
+    monkeypatch.setenv("HOTMEM_URL", "http://localhost:8711")
+    p = HotMemMemoryProvider()
+    assert p.is_available() is True
+
+
+def test_save_config_writes_json(tmp_path):
+    from hotmem_hermes import HotMemMemoryProvider
+
+    p = HotMemMemoryProvider()
+    p.save_config({"hotmem_url": "http://x:1"}, str(tmp_path))
+    cfg = json.loads((tmp_path / "hotmem.json").read_text())
+    assert cfg["hotmem_url"] == "http://x:1"
+
+
+def test_tool_schemas():
+    from hotmem_hermes import HotMemMemoryProvider
+
+    p = HotMemMemoryProvider()
+    names = [t["name"] for t in p.get_tool_schemas()]
+    assert names == ["hotmem_search", "hotmem_store"]
+
+
+def test_handle_tool_store_and_search(hotmem_app):
+    from hotmem_hermes import HotMemMemoryProvider
+
+    p = HotMemMemoryProvider()
+    p._client = _make_async_client(hotmem_app)
+
+    async def go():
+        res = await p.handle_tool_call(
+            "hotmem_store",
+            {
+                "identifier": "vendor_a",
+                "fact": "Invoice total $5000",
+                "importance": 0.8,
+            },
+        )
+        assert "memory_id" in res
+
+        out = await p.handle_tool_call("hotmem_search", {"query": "invoice", "top_k": 5})
+        assert out["count"] >= 1
+        assert "Invoice" in out["memories"][0]["content"]
+
+    asyncio.run(go())
+
+
+def test_prefetch_returns_recall(hotmem_app):
+    from hotmem_hermes import HotMemMemoryProvider
+
+    p = HotMemMemoryProvider()
+    p._client = _make_async_client(hotmem_app)
+    asyncio.run(p._client.add("env", "Staging SSH on port 2222"))
+
+    recall = asyncio.run(p.prefetch("staging ssh port"))
+    assert "HotMem recall:" in recall
+    assert "2222" in recall
+
+
+def test_sync_turn_persists_async(hotmem_app):
+    from hotmem_hermes import HotMemMemoryProvider
+
+    p = HotMemMemoryProvider()
+    p._client = _make_async_client(hotmem_app)
+    p._session_id = "sess-1"
+
+    p.sync_turn("what is the staging port?", "it is 2222")
+    if p._sync_thread:
+        p._sync_thread.join(timeout=10.0)
+
+    memories = asyncio.run(p._client.search("staging port"))
+    contents = " ".join(m["content"] for m in memories)
+    assert "2222" in contents
+
+
+def test_attach_sync_adds_hooks(hotmem_app):
+    from hotmem_hermes import HotMemMemoryProvider
+    from hotmem_hermes.sync import attach_sync
+
+    p = HotMemMemoryProvider()
+    p._client = _make_async_client(hotmem_app)
+    attach_sync(p)
+    assert callable(p.on_memory_write)
+    assert callable(p.on_pre_compress)
+    assert callable(p.on_session_end)
+
+
+def test_on_memory_write_mirrors(hotmem_app):
+    from hotmem_hermes import HotMemMemoryProvider
+    from hotmem_hermes.sync import attach_sync
+
+    p = HotMemMemoryProvider()
+    p._client = _make_async_client(hotmem_app)
+    attach_sync(p)
+
+    p.on_memory_write("add", "user", "Prefers terse answers")
+    p.on_memory_write("add", "memory", "Staging on port 2222")
+    if p._sync_thread:
+        p._sync_thread.join(timeout=10.0)
+
+    memories = asyncio.run(p._client.search("user preferences"))
+    contents = " ".join(m["content"] for m in memories)
+    assert "terse" in contents
+
+
+def test_on_pre_compress_extracts_durable(hotmem_app):
+    from hotmem_hermes import HotMemMemoryProvider
+    from hotmem_hermes.sync import attach_sync
+
+    p = HotMemMemoryProvider()
+    p._client = _make_async_client(hotmem_app)
+    attach_sync(p)
+
+    messages = [
+        {"role": "user", "content": "what time is it?"},
+        {"role": "assistant", "content": "it is noon"},
+        {"role": "user", "content": "actually, remember that deploy uses blue-green"},
+    ]
+    p.on_pre_compress(messages)
+    if p._sync_thread:
+        p._sync_thread.join(timeout=10.0)
+
+    memories = asyncio.run(p._client.search("blue-green deploy"))
+    assert len(memories) >= 1
+
+
+def test_on_session_end_snapshot_hydrate_round_trip(hotmem_app, tmp_path):
+    """No data loss on restart: snapshot -> hydrate recovers memories."""
+    from hotmem_hermes import HotMemMemoryProvider
+    from hotmem_hermes.sync import attach_sync
+
+    transport, swap_path = hotmem_app
+    p = HotMemMemoryProvider()
+    p._client = _make_async_client(hotmem_app)
+    p._swap_path = str(swap_path)
+    attach_sync(p)
+
+    asyncio.run(p._client.add("persist", "survive restart", importance=0.9))
+    p.on_session_end([])
+    if p._sync_thread:
+        p._sync_thread.join(timeout=10.0)
+
+    assert Path(swap_path).exists()
+
+    # New DB + hydrate from swap
+    new_db = tmp_path / "restarted.sqlite"
+    new_app = create_app(db_path=new_db, swap_path=str(swap_path))
+    with TestClient(new_app) as new_transport:
+        import httpx
+        from hotmem.client import AsyncHotMemClient
+
+        c = AsyncHotMemClient.__new__(AsyncHotMemClient)
+        c.base_url = "http://testserver"
+        c._client = httpx.AsyncClient(
+            base_url=c.base_url, transport=httpx.ASGITransport(app=new_transport.app)
+        )
+        recovered = asyncio.run(c.search("survive restart"))
+        asyncio.run(c.close())
+
+    assert len(recovered) >= 1
+    assert "survive restart" in recovered[0]["content"]
+
+
+def test_register_attaches_sync():
+    from hotmem_hermes.provider import register
+
+    class FakeCtx:
+        provider = None
+
+        def register_memory_provider(self, p):
+            self.provider = p
+
+    ctx = FakeCtx()
+    register(ctx)
+    assert ctx.provider.name == "hotmem"
+    assert callable(ctx.provider.on_memory_write)

--- a/adapters/langchain/README.md
+++ b/adapters/langchain/README.md
@@ -1,0 +1,42 @@
+# hotmem-langchain
+
+LangChain adapter for the [HotMem](https://github.com/KnowGuard-AI/HotMem) memory sidecar.
+
+Provides `HotMemChatMessageHistory` and `HotMemRetriever` backed by HotMem's hybrid vector + FTS5 search.
+
+## Install
+
+```sh
+pip install hotmem-langchain
+```
+
+## Quickstart
+
+```sh
+hotmem serve  # start the sidecar on http://127.0.0.1:8711
+```
+
+```python
+from hotmem_langchain import HotMemChatMessageHistory, HotMemRetriever
+
+# Chat message history
+history = HotMemChatMessageHistory("session-1")
+history.add_user_message("User prefers dark mode")
+history.add_ai_message("Got it, dark mode enabled.")
+
+# Retriever
+retriever = HotMemRetriever(top_k=5)
+docs = retriever.invoke("user preferences")
+# [Document(page_content="User prefers dark mode", metadata={"score": 0.92, ...})]
+```
+
+## Classes
+
+| Class | LangChain base | Purpose |
+| --- | --- | --- |
+| `HotMemChatMessageHistory` | `BaseChatMessageHistory` | Persist conversation turns |
+| `HotMemRetriever` | `BaseRetriever` | Retrieve `Document` objects from search |
+
+## License
+
+MIT

--- a/adapters/langchain/hotmem_langchain/__init__.py
+++ b/adapters/langchain/hotmem_langchain/__init__.py
@@ -1,0 +1,10 @@
+"""HotMem LangChain adapter.
+
+Exposes HotMem as a LangChain BaseChatMessageHistory and BaseRetriever.
+"""
+
+from hotmem_langchain.message_history import HotMemChatMessageHistory
+from hotmem_langchain.retriever import HotMemRetriever
+
+__all__ = ["HotMemChatMessageHistory", "HotMemRetriever"]
+__version__ = "0.1.0"

--- a/adapters/langchain/hotmem_langchain/message_history.py
+++ b/adapters/langchain/hotmem_langchain/message_history.py
@@ -1,0 +1,76 @@
+"""LangChain BaseChatMessageHistory backed by HotMem."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hotmem.client import HotMemClient
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+
+class HotMemChatMessageHistory(BaseChatMessageHistory):
+    """Persist chat messages to HotMem under a shared identifier.
+
+    The session id is used as the HotMem identifier so all messages in a
+    conversation are grouped and searchable together.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        base_url: str = "http://127.0.0.1:8711",
+        client: HotMemClient | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self._client = client or HotMemClient(base_url)
+
+    @property
+    def client(self) -> HotMemClient:
+        return self._client
+
+    def add_message(self, message: Any) -> None:
+        role = getattr(message, "type", None) or "system"
+        self._client.add(
+            identifier=self.session_id,
+            fact=message.content,
+            source=f"langchain:{role}",
+            importance=0.5,
+            metadata={"role": role},
+        )
+
+    def add_user_message(self, message: str) -> None:
+        self.add_message(HumanMessage(content=message))
+
+    def add_ai_message(self, message: str) -> None:
+        self.add_message(AIMessage(content=message))
+
+    def messages(self) -> list[Any]:
+        """Return messages for this session.
+
+        Note: HotMem search returns results ranked by relevance, not
+        insertion order. Until HotMem exposes timestamps, ordering is
+        best-effort by score.
+        """
+        memories = self._client.search(self.session_id, top_k=100, max_chars=10_000)
+        out: list[Any] = []
+        for m in memories:
+            role = (
+                m.get("metadata", {}).get("role", m.get("role", "system"))
+                if isinstance(m.get("metadata"), dict)
+                else m.get("role", "system")
+            )
+            content = m["content"]
+            if role == "human":
+                out.append(HumanMessage(content=content))
+            elif role == "ai":
+                out.append(AIMessage(content=content))
+            else:
+                out.append(SystemMessage(content=content))
+        return out
+
+    def clear(self) -> None:
+        # HotMem v0.1 has no delete; clearing is a no-op.
+        # Future versions may support TTL-based expiry per identifier.
+        pass

--- a/adapters/langchain/hotmem_langchain/retriever.py
+++ b/adapters/langchain/hotmem_langchain/retriever.py
@@ -1,0 +1,52 @@
+"""LangChain BaseRetriever backed by HotMem search."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hotmem.client import HotMemClient
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from pydantic import PrivateAttr
+
+
+class HotMemRetriever(BaseRetriever):
+    """Retrieve LangChain Documents from HotMem hybrid search."""
+
+    base_url: str = "http://127.0.0.1:8711"
+    top_k: int = 5
+    max_chars: int | None = None
+    _client: HotMemClient = PrivateAttr()
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self._client = HotMemClient(self.base_url)
+
+    @property
+    def client(self) -> HotMemClient:
+        return self._client
+
+    def _get_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun,
+    ) -> list[Document]:
+        memories = self._client.search(
+            query,
+            top_k=self.top_k,
+            max_chars=self.max_chars,
+        )
+        return [
+            Document(
+                page_content=m["content"],
+                metadata={
+                    "memory_id": m["memory_id"],
+                    "identifier": m["identifier"],
+                    "score": m["score"],
+                    "source": "hotmem",
+                },
+            )
+            for m in memories
+        ]

--- a/adapters/langchain/pyproject.toml
+++ b/adapters/langchain/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "hotmem-langchain"
+version = "0.1.0"
+description = "LangChain adapter for the HotMem memory sidecar"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "valiantone", email = "zrjohn@yahoo.com" }]
+
+dependencies = [
+    "hotmem>=0.1.8",
+    "langchain-core>=0.3,<1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9,<10",
+    "ruff>=0.15,<1",
+]
+
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/adapters/langchain/tests/test_langchain.py
+++ b/adapters/langchain/tests/test_langchain.py
@@ -1,0 +1,58 @@
+"""Tests for hotmem_langchain — back the adapters with a real in-process server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from hotmem.server import create_app
+
+
+@pytest.fixture
+def hotmem_url(tmp_path: Path) -> str:
+    db_path = tmp_path / "langchain_test.sqlite"
+    app = create_app(db_path=db_path)
+    with TestClient(app) as transport:
+        yield transport
+
+
+def _make_client(hotmem_url, base_url: str = "http://testserver"):
+    from hotmem.client import HotMemClient
+
+    c = HotMemClient.__new__(HotMemClient)
+    c.base_url = base_url
+    c._client = hotmem_url
+    return c
+
+
+def test_message_history_round_trip(hotmem_url):
+    from hotmem_langchain import HotMemChatMessageHistory
+
+    hist = HotMemChatMessageHistory.__new__(HotMemChatMessageHistory)
+    hist.session_id = "sess-1"
+    hist._client = _make_client(hotmem_url)
+
+    hist.add_user_message("hello there")
+    hist.add_ai_message("hi! how can I help?")
+
+    msgs = hist.messages()
+    assert len(msgs) == 2
+    contents = {m.content for m in msgs}
+    assert contents == {"hello there", "hi! how can I help?"}
+
+
+def test_retriever_returns_documents(hotmem_url):
+    from hotmem_langchain import HotMemRetriever
+
+    client = _make_client(hotmem_url)
+    client.add("vendor_x", "Invoice total $5000 detected", importance=0.9)
+
+    retriever = HotMemRetriever(base_url="http://testserver")
+    retriever._client = client
+
+    docs = retriever.invoke("invoice")
+    assert len(docs) >= 1
+    assert "Invoice" in docs[0].page_content
+    assert docs[0].metadata["source"] == "hotmem"
+    assert "score" in docs[0].metadata

--- a/adapters/pydanticai/README.md
+++ b/adapters/pydanticai/README.md
@@ -1,0 +1,46 @@
+# hotmem-pydanticai
+
+Pydantic AI dependency and tool provider for the [HotMem](https://github.com/KnowGuard-AI/HotMem) memory sidecar.
+
+## Install
+
+```sh
+pip install hotmem-pydanticai
+```
+
+## Quickstart
+
+```sh
+hotmem serve
+```
+
+```python
+from pydantic_ai import Agent
+from hotmem_pydanticai import HotMemDeps, recall_system_prompt
+
+agent = Agent("openai:gpt-4o", deps_type=HotMemDeps)
+agent.system_prompt(recall_system_prompt)
+
+# optional: a tool to store facts
+@agent.tool
+async def remember(ctx, fact: str) -> str:
+    ctx.deps.client.add(ctx.deps.identifier, fact)
+    return "remembered"
+
+deps = HotMemDeps.from_url("http://127.0.0.1:8711")
+result = await agent.run("What do you know about my preferences?", deps=deps)
+print(result.output)
+```
+
+## API
+
+| Object | Description |
+| --- | --- |
+| `HotMemDeps` | Dependency dataclass — holds a `HotMemClient`, identifier, top_k |
+| `HotMemDeps.recall(query)` | Return ranked memories as a context string |
+| `HotMemDeps.from_url(base_url)` | Convenience constructor |
+| `recall_system_prompt(ctx)` | System prompt function injecting recall |
+
+## License
+
+MIT

--- a/adapters/pydanticai/hotmem_pydanticai/__init__.py
+++ b/adapters/pydanticai/hotmem_pydanticai/__init__.py
@@ -1,0 +1,9 @@
+"""HotMem Pydantic AI adapter.
+
+Exposes HotMem as a Pydantic AI dependency and tool provider.
+"""
+
+from hotmem_pydanticai.provider import HotMemDeps, recall_system_prompt
+
+__all__ = ["HotMemDeps", "recall_system_prompt"]
+__version__ = "0.1.0"

--- a/adapters/pydanticai/hotmem_pydanticai/provider.py
+++ b/adapters/pydanticai/hotmem_pydanticai/provider.py
@@ -1,0 +1,53 @@
+"""Pydantic AI dependency and tools backed by HotMem."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from hotmem.client import HotMemClient
+
+
+@dataclass
+class HotMemDeps:
+    """Dependency container exposing HotMem to a Pydantic AI agent.
+
+    Pass as `deps_type=HotMemDeps` to the Agent and inject an instance at
+    run time. Tools access the client via `ctx.deps.client`.
+    """
+
+    client: HotMemClient
+    identifier: str = "pydanticai"
+    top_k: int = 5
+
+    @classmethod
+    def from_url(cls, base_url: str = "http://127.0.0.1:8711", **kwargs: Any) -> HotMemDeps:
+        return cls(client=HotMemClient(base_url), **kwargs)
+
+    def recall(self, query: str) -> str:
+        """Return ranked memories as a context string."""
+        memories = self.client.search(query, top_k=self.top_k)
+        if not memories:
+            return ""
+        lines = [f"- {m['content']}" for m in memories]
+        return "Relevant memories:\n" + "\n".join(lines)
+
+
+async def recall_system_prompt(ctx: Any) -> str:
+    """System prompt function that injects HotMem recall.
+
+    Usage::
+
+        from pydantic_ai import Agent
+        from hotmem_pydanticai import HotMemDeps, recall_system_prompt
+
+        agent = Agent('openai:gpt-4o', deps_type=HotMemDeps)
+        agent.system_prompt(recall_system_prompt)
+
+        deps = HotMemDeps.from_url()
+        result = await agent.run('question', deps=deps)
+    """
+    deps = ctx.deps
+    if not isinstance(deps, HotMemDeps):
+        return ""
+    return deps.recall(ctx.prompt if hasattr(ctx, "prompt") else "")

--- a/adapters/pydanticai/pyproject.toml
+++ b/adapters/pydanticai/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "hotmem-pydanticai"
+version = "0.1.0"
+description = "Pydantic AI tool provider and dependency for the HotMem memory sidecar"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "valiantone", email = "zrjohn@yahoo.com" }]
+
+dependencies = [
+    "hotmem>=0.1.8",
+    "pydantic-ai>=0.0.30,<1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9,<10",
+    "ruff>=0.15,<1",
+]
+
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/adapters/pydanticai/tests/test_pydanticai.py
+++ b/adapters/pydanticai/tests/test_pydanticai.py
@@ -1,0 +1,62 @@
+"""Tests for hotmem_pydanticai."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from hotmem.server import create_app
+
+
+@pytest.fixture
+def hotmem_url(tmp_path: Path) -> str:
+    db_path = tmp_path / "pydanticai_test.sqlite"
+    app = create_app(db_path=db_path)
+    with TestClient(app) as transport:
+        yield transport
+
+
+def _make_client(hotmem_url):
+    from hotmem.client import HotMemClient
+
+    c = HotMemClient.__new__(HotMemClient)
+    c.base_url = "http://testserver"
+    c._client = hotmem_url
+    return c
+
+
+def test_deps_recall(hotmem_url):
+    from hotmem_pydanticai import HotMemDeps
+
+    client = _make_client(hotmem_url)
+    client.add("proj", "Uses tabs, 120-char lines, Google docstrings", importance=0.8)
+
+    deps = HotMemDeps(client=client, top_k=5)
+    recall = deps.recall("code style conventions")
+    assert "Relevant memories:" in recall
+    assert "tabs" in recall
+
+
+def test_deps_recall_empty(hotmem_url):
+    from hotmem_pydanticai import HotMemDeps
+
+    client = _make_client(hotmem_url)
+    deps = HotMemDeps(client=client)
+    assert deps.recall("nothing here at all zzzz") == ""
+
+
+def test_recall_system_prompt(hotmem_url):
+    import asyncio
+
+    from hotmem_pydanticai import HotMemDeps, recall_system_prompt
+
+    client = _make_client(hotmem_url)
+    client.add("user", "Prefers terse answers", importance=0.9)
+
+    class FakeCtx:
+        deps = HotMemDeps(client=client, top_k=5)
+        prompt = "answer style"
+
+    result = asyncio.run(recall_system_prompt(FakeCtx()))
+    assert "terse" in result

--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/ts/README.md
+++ b/ts/README.md
@@ -1,0 +1,53 @@
+# hotmem
+
+A typed, zero-dependency TypeScript client for the [HotMem](https://github.com/KnowGuard-AI/HotMem) local-first memory sidecar.
+
+Uses the global `fetch` — works in **Node.js 18+**, **Deno**, **Bun**, and edge runtimes (Cloudflare Workers).
+
+## Install
+
+```sh
+npm install hotmem
+```
+
+## Quickstart
+
+```sh
+hotmem serve  # start the sidecar on http://127.0.0.1:8711
+```
+
+```typescript
+import { HotMemClient } from "hotmem";
+
+const client = new HotMemClient("http://127.0.0.1:8711");
+
+await client.add("vendor_x", "Invoice total $5000", { importance: 0.8 });
+await client.add("vendor_x", "Prefers email over phone", {
+  source: "intake-call",
+  ttlSeconds: 86400,
+});
+
+const memories = await client.search("duplicate invoice risk", { topK: 5 });
+// memories[0] => { role: "system", content: "...", score: 0.92, ... }
+
+const health = await client.health();
+console.log(`${health.memory_count} memories stored`);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `add(identifier, fact, options?)` | Store a fact. Options: `source`, `importance` (0-1), `metadata`, `ttlSeconds` |
+| `search(query, options?)` | Hybrid-ranked search. Options: `topK` (default 5), `maxChars` |
+| `health()` | Server status: memory count, uptime, db path |
+| `hydrate(file?)` | Load memories from a JSONL swap file |
+| `snapshot(file?)` | Export all memories to a JSONL swap file |
+
+## Errors
+
+Non-2xx responses throw a `HotMemError` with `status` and `body`. Network failures also throw `HotMemError` with `status: 0`.
+
+## License
+
+MIT

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,0 +1,2460 @@
+{
+  "name": "hotmem",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hotmem",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "hotmem",
+  "version": "0.1.0",
+  "description": "A typed TypeScript client for the HotMem local-first memory sidecar.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "memory",
+    "agent",
+    "llm",
+    "sidecar",
+    "vector-search",
+    "hotmem"
+  ],
+  "license": "MIT",
+  "author": "valiantone",
+  "homepage": "https://github.com/KnowGuard-AI/HotMem",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/KnowGuard-AI/HotMem",
+    "directory": "ts"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  },
+  "allowScripts": {
+    "esbuild@0.27.7": true,
+    "esbuild@0.21.5": true
+  }
+}

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -1,0 +1,137 @@
+import type {
+  AddOptions,
+  AddResponse,
+  HealthResponse,
+  HydrateResponse,
+  Memory,
+  SearchOptions,
+  SnapshotResponse,
+} from "./types.js";
+import { HotMemError } from "./types.js";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8711";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Typed TypeScript client for the HotMem HTTP API.
+ *
+ * Uses the global `fetch` — zero dependencies. Works in Node.js 18+,
+ * Deno, Bun, and edge runtimes (Cloudflare Workers).
+ *
+ * @example
+ * const client = new HotMemClient("http://127.0.0.1:8711");
+ * await client.add("vendor_x", "Invoice total $5000", { importance: 0.8 });
+ * const memories = await client.search("duplicate invoice risk", { topK: 5 });
+ */
+export class HotMemClient {
+  readonly baseUrl: string;
+  private readonly timeoutMs: number;
+
+  constructor(baseUrl: string = DEFAULT_BASE_URL, timeoutMs: number = DEFAULT_TIMEOUT_MS) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.timeoutMs = timeoutMs;
+  }
+
+  /** Check server health. */
+  async health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/v1/health");
+  }
+
+  /**
+   * Add a fact to memory.
+   * @returns The stored memory id and content hash.
+   */
+  async add(
+    identifier: string,
+    fact: string,
+    options: AddOptions = {},
+  ): Promise<AddResponse> {
+    const payload: Record<string, unknown> = {
+      identifier,
+      fact,
+      source: options.source ?? "",
+      importance: options.importance ?? 0.5,
+      metadata: options.metadata ?? {},
+    };
+    if (options.ttlSeconds !== undefined) {
+      payload.ttl_seconds = options.ttlSeconds;
+    }
+    return this.request<AddResponse>("POST", "/v1/add", payload);
+  }
+
+  /**
+   * Search memories and return ranked, LLM-ready message objects.
+   * @returns An array of memories sorted by relevance.
+   */
+  async search(query: string, options: SearchOptions = {}): Promise<Memory[]> {
+    const payload: Record<string, unknown> = {
+      query,
+      top_k: options.topK ?? 5,
+    };
+    if (options.maxChars !== undefined) {
+      payload.max_chars = options.maxChars;
+    }
+    const res = await this.request<{ memories: Memory[] }>("POST", "/v1/search", payload);
+    return res.memories;
+  }
+
+  /** Trigger swap file hydration. */
+  async hydrate(file?: string): Promise<HydrateResponse> {
+    const payload: Record<string, unknown> = {};
+    if (file !== undefined) {
+      payload.file = file;
+    }
+    return this.request<HydrateResponse>("POST", "/v1/hydrate", payload);
+  }
+
+  /** Trigger database snapshot to swap file. */
+  async snapshot(file?: string): Promise<SnapshotResponse> {
+    const payload: Record<string, unknown> = {};
+    if (file !== undefined) {
+      payload.file = file;
+    }
+    return this.request<SnapshotResponse>("POST", "/v1/snapshot", payload);
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const init: RequestInit = {
+      method,
+      headers: { "content-type": "application/json" },
+      signal: AbortSignal.timeout(this.timeoutMs),
+    };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+
+    let resp: Response;
+    try {
+      resp = await fetch(url, init);
+    } catch (err) {
+      throw new HotMemError(`request failed: ${err instanceof Error ? err.message : String(err)}`, 0, err);
+    }
+
+    let json: unknown = undefined;
+    const text = await resp.text();
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        json = text;
+      }
+    }
+
+    if (!resp.ok) {
+      const message = typeof json === "object" && json && "detail" in json
+        ? String((json as Record<string, unknown>).detail)
+        : `HTTP ${resp.status}`;
+      throw new HotMemError(message, resp.status, json);
+    }
+
+    return json as T;
+  }
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,0 +1,11 @@
+export { HotMemClient } from "./client.js";
+export {
+  HotMemError,
+  type AddOptions,
+  type AddResponse,
+  type HealthResponse,
+  type HydrateResponse,
+  type Memory,
+  type SearchOptions,
+  type SnapshotResponse,
+} from "./types.js";

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -1,0 +1,82 @@
+/** Request/response types for the HotMem HTTP API. */
+
+export interface AddOptions {
+  source?: string;
+  importance?: number;
+  metadata?: Record<string, unknown>;
+  ttlSeconds?: number;
+}
+
+export interface AddRequest {
+  identifier: string;
+  fact: string;
+  source: string;
+  importance: number;
+  metadata: Record<string, unknown>;
+  ttl_seconds?: number;
+}
+
+export interface AddResponse {
+  memory_id: string;
+  content_hash: string;
+  trace_ms: number;
+}
+
+export interface SearchOptions {
+  topK?: number;
+  maxChars?: number;
+}
+
+export interface SearchRequest {
+  query: string;
+  top_k: number;
+  max_chars?: number;
+}
+
+/** A ranked, LLM-ready message object returned by search. */
+export interface Memory {
+  role: string;
+  content: string;
+  memory_id: string;
+  identifier: string;
+  score: number;
+}
+
+export interface SearchResponse {
+  memories: Memory[];
+  count: number;
+  trace_ms: number;
+}
+
+export interface HealthResponse {
+  status: string;
+  memory_count: number;
+  db_path: string;
+  uptime_s: number;
+}
+
+export interface HydrateRequest {
+  file?: string;
+}
+
+export interface HydrateResponse {
+  loaded: number;
+  skipped_dupes: number;
+}
+
+export interface SnapshotResponse {
+  exported: number;
+  path: string;
+}
+
+export class HotMemError extends Error {
+  status: number;
+  body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "HotMemError";
+    this.status = status;
+    this.body = body;
+  }
+}

--- a/ts/tests/client.test.ts
+++ b/ts/tests/client.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HotMemClient, HotMemError } from "../src/index.js";
+
+type FetchCall = { url: string; init: RequestInit };
+
+function mockFetch(handler: (call: FetchCall) => { status: number; body: unknown }) {
+  const calls: FetchCall[] = [];
+  const fn = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    const { status, body } = handler({ url, init });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return calls;
+}
+
+describe("HotMemClient", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips trailing slashes from base url", () => {
+    const c = new HotMemClient("http://localhost:8711///");
+    expect(c.baseUrl).toBe("http://localhost:8711");
+  });
+
+  it("health() GETs /v1/health", async () => {
+    const calls = mockFetch(() => ({
+      status: 200,
+      body: { status: "ok", memory_count: 3, db_path: "/data/h.sqlite", uptime_s: 1.2 },
+    }));
+    const c = new HotMemClient();
+    const res = await c.health();
+    expect(res.status).toBe("ok");
+    expect(res.memory_count).toBe(3);
+    expect(calls[0].url).toBe("http://127.0.0.1:8711/v1/health");
+    expect(calls[0].init.method).toBe("GET");
+  });
+
+  it("add() POSTs to /v1/add with defaults", async () => {
+    const calls = mockFetch(() => ({
+      status: 200,
+      body: { memory_id: "m1", content_hash: "abc", trace_ms: 1.0 },
+    }));
+    const c = new HotMemClient();
+    const res = await c.add("vendor_x", "Invoice total $5000", { importance: 0.8 });
+    expect(res.memory_id).toBe("m1");
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body).toEqual({
+      identifier: "vendor_x",
+      fact: "Invoice total $5000",
+      source: "",
+      importance: 0.8,
+      metadata: {},
+    });
+  });
+
+  it("add() includes ttl_seconds when provided", async () => {
+    const calls = mockFetch(() => ({ status: 200, body: { memory_id: "m" } }));
+    const c = new HotMemClient();
+    await c.add("v", "f", { ttlSeconds: 3600 });
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.ttl_seconds).toBe(3600);
+  });
+
+  it("search() returns ranked memories", async () => {
+    mockFetch(() => ({
+      status: 200,
+      body: {
+        memories: [{ role: "system", content: "fact", memory_id: "m1", identifier: "v", score: 0.9 }],
+        count: 1,
+        trace_ms: 0.5,
+      },
+    }));
+    const c = new HotMemClient();
+    const mems = await c.search("risk", { topK: 5, maxChars: 100 });
+    expect(mems).toHaveLength(1);
+    expect(mems[0].role).toBe("system");
+    expect(mems[0].score).toBe(0.9);
+  });
+
+  it("hydrate() and snapshot() pass optional file", async () => {
+    const calls = mockFetch(({ url }) => {
+      if (url.endsWith("/v1/hydrate")) {
+        return { status: 200, body: { loaded: 1, skipped_dupes: 0 } };
+      }
+      return { status: 200, body: { exported: 1, path: "swap.jsonl" } };
+    });
+    const c = new HotMemClient();
+    expect(await c.hydrate("swap.jsonl")).toEqual({ loaded: 1, skipped_dupes: 0 });
+    expect(await c.snapshot("swap.jsonl")).toEqual({ exported: 1, path: "swap.jsonl" });
+    expect(JSON.parse(calls[0].init.body as string).file).toBe("swap.jsonl");
+  });
+
+  it("throws HotMemError on non-2xx with detail", async () => {
+    mockFetch(() => ({ status: 400, body: { detail: "bad request" } }));
+    const c = new HotMemClient();
+    await expect(c.search("x")).rejects.toMatchObject({
+      name: "HotMemError",
+      status: 400,
+      message: "bad request",
+    });
+  });
+
+  it("throws HotMemError on network failure", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const c = new HotMemClient();
+    await expect(c.health()).rejects.toBeInstanceOf(HotMemError);
+  });
+});

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/ts/tsup.config.ts
+++ b/ts/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  target: "es2022",
+  platform: "neutral",
+});


### PR DESCRIPTION
## Summary

Closes #9, #10, #31, #32 in one branch — Phase 2 ecosystem expansion.

Makes HotMem the memory layer across the agent ecosystem. Core stays zero-dep; every integration is a separate installable package in `adapters/` (Python) or `ts/` (npm).

### TypeScript client (#10)
`ts/` — a zero-dependency, typed `HotMemClient` mirroring the Python SDK (`add`, `search`, `health`, `hydrate`, `snapshot`). Builds to ESM + CJS + `.d.ts` via tsup. Works in Node 18+, Deno, Bun, and edge runtimes (uses global `fetch`).

### Framework adapters (#9)
Four thin adapters wrapping `HotMemClient`, each `pip install`-able:
- **`hotmem-langchain`** — `HotMemChatMessageHistory` (`BaseChatMessageHistory`) + `HotMemRetriever` (`BaseRetriever`)
- **`hotmem-crewai`** — `HotMemMemory` (save/search/load)
- **`hotmem-autogen`** — `HotMemMemoryPlugin` (add_context/save/search)
- **`hotmem-pydanticai`** — `HotMemDeps` dependency + `recall_system_prompt` system-prompt function

### Hermes Agent deep integration (#31, #32)
`hotmem-hermes` implements the official Hermes [Memory Provider Plugin](https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin) ABC — `memory.provider: hotmem`. This is the deep path (the existing MCP server stays as the shallow fallback).

- **#31 — provider plugin**: lifecycle (`initialize`/`prefetch`/`sync_turn`/`shutdown`), tool schemas (`hotmem_search`/`hotmem_store`), config schema for `hermes memory setup`, and `hermes hotmem status`/`config` CLI.
- **#32 — sync layer**: `on_memory_write` mirrors `MEMORY.md`/`USER.md` writes to HotMem with biased importance (user 0.9 / memory 0.8); `on_pre_compress` extracts durable-looking facts before context compression (heuristic, no LLM); `on_session_end` snapshots to a profile-scoped swap file. Plus a `hotmem-memory` skill (agentskills.io standard) teaching the agent to persist learnings proactively.

## Test plan
- [x] Python: 89 tests passing (core + 5 adapters) — `uv run pytest src tests adapters`
- [x] TypeScript: 8 tests passing — `npm test` (fetch mocked)
- [x] TS build clean (ESM + CJS + d.ts) — `npm run build`
- [x] `ruff check` + `ruff format --check` clean across `src/ tests/ adapters/`
- [x] `tsc --noEmit` clean
- [x] Snapshot → hydrate round-trip verified (no data loss on restart)
- [x] Sync hooks non-blocking (daemon thread, joinable via `provider._sync_thread`)

CI adds an `adapters` job (Python 3.11/3.13 matrix) and a `typescript` job (Node 18/20 matrix).

## Notes

**Model & budget used for this work:**
- Model: `z-ai/glm-5.2` (OpenRouter ID `openrouter/z-ai/glm-5.2`)
- Approach: single-shot planning + iterative implementation with the in-repo toolchain (ruff, pytest, vitest, tsup) as the verification loop — no external API spend beyond the editing model itself.

🤖 Generated with [Kilo](https://github.com/Kilo-Org/kilocode)
