### PR TITLE
vNext M0+M1: RFC + Memory Record v2 + Storage Adapter

### DIFF
--- a/docs/vnext/0001-file-aware-sidecar.md
+++ b/docs/vnext/0001-file-aware-sidecar.md
@@ -1,0 +1,261 @@
+# RFC 0001: File-Aware Memory Sidecar
+
+Status: Draft
+Tracks: #35
+Related: #36 #37 #38 #39 #40 #41 #42 #43
+
+## 1. Goal
+
+Evolve HotMem from a JSON memory store into a **file-aware, provenance-first
+memory sidecar** while preserving its core principles:
+
+- local-first
+- extremely lightweight
+- deterministic
+- embeddable
+- language agnostic
+- no heavy analytical engine
+- optimized for fast memory ingestion and hydration
+
+HotMem remains the **runtime memory device for EMOS**, not the analytical or
+storage engine.
+
+## 2. HotMem-owns / EMOS-owns boundary
+
+HotMem owns:
+- hot memory, memory API, memory schema
+- snapshots, hydration, provenance
+- storage abstraction (interface only)
+- event log, promotion signalling
+
+EMOS owns:
+- Parquet, Arrow, DuckDB, Polars
+- HDFS, S3, object storage, data lake
+- analytical execution, compaction
+- memory hierarchy, lineage reconstruction
+
+HotMem must NOT become DuckDB/Polars/a data lake, manage Parquet partitions,
+execute analytical workloads, or own object-storage orchestration.
+
+## 3. Memory Record v2
+
+### 3.1 v0.1 → v2 field mapping
+
+| v0.1 column | v2 field | Notes |
+|---|---|---|
+| id | id | unchanged |
+| identifier | identifier | unchanged |
+| fact_text | content | renamed in payload only; column stays `fact_text` for compat |
+| embedding | embedding | unchanged |
+| embedding_dim | embedding_dim | unchanged |
+| embedding_model | embedding_model | unchanged |
+| source | source | kept (free-text legacy); superseded by `source_uri` |
+| importance | importance | unchanged |
+| metadata_json | metadata_json | unchanged |
+| content_hash | content_hash | unchanged |
+| ttl_seconds | ttl_seconds | unchanged |
+| created_at | created_at | pre-existing (owned by #34 for surfacing, not #36) |
+| — | namespace | new |
+| — | tier | new (default `hot`) |
+| — | memory_type | new (default `fact`) |
+| — | source_uri | new (provenance) |
+| — | source_format | new |
+| — | source_checksum | new |
+| — | byte_offset | new (file ref) |
+| — | byte_length | new (file ref) |
+| — | updated_at | new (#36 owns this; `created_at` already exists) |
+| — | snapshot_id | new |
+| — | promotion_state | new (default `HOT`) |
+| — | promotion_candidate | new (default 0) |
+| — | parent_memory | new |
+| — | related_memories | new (JSON array string) |
+| — | tags | new (JSON array string) |
+| — | schema_version | new (default 1; DB `user_version` pragma = 2) |
+
+### 3.2 Compatibility rules
+
+- All new columns are **additive** with safe defaults; v0.1 DBs open unchanged.
+- `fact_text` column name is retained (payload alias `content` is a future API concern, not schema).
+- `source` (singular) is retained for legacy callers; `source_uri` is the v2 provenance field.
+- `created_at` is **not** a #36 addition; #34 owns its surfacing and retrieval.
+- DB-level version tracked via `PRAGMA user_version` (1 → 2).
+
+## 4. Storage Adapter
+
+### 4.1 Interface
+
+```python
+class StorageAdapter(Protocol):
+    def read(self, uri: str) -> bytes: ...
+    def read_range(self, uri: str, offset: int, length: int) -> bytes: ...
+    def exists(self, uri: str) -> bool: ...
+    def metadata(self, uri: str) -> dict: ...  # size, mtime, format
+    def checksum(self, uri: str) -> str: ...   # sha256 hex
+```
+
+### 4.2 Scheme registry
+
+A literal dict in `storage/__init__.py` maps scheme → adapter. Unknown
+schemes raise an explicit error: "scheme `<x>` is owned by EMOS, not HotMem".
+
+### 4.3 Initial implementation
+
+Local filesystem only (`file://` and bare paths). Range reads use seek+read
+(no full-file load); checksum is sha256 with `lru_cache`; metadata infers
+format from extension. Optional mmap path for large files.
+
+S3/HDFS/Azure/GCS are **future** and out of scope — EMOS owns distributed
+storage; HotMem only understands the abstraction.
+
+## 5. Snapshot v2
+
+### 5.1 Layout
+
+```
+snapshot/
+  manifest.json
+  memories.jsonl
+  attachments/
+  metadata.json
+```
+
+### 5.2 Manifest schema
+
+```json
+{
+  "schema_version": 2,
+  "snapshot_id": "<uuid>",
+  "created_at": "<iso8601>",
+  "hashes": { "memories.jsonl": "<sha256>", "metadata.json": "<sha256>" },
+  "overall_checksum": "<sha256>",
+  "file_references": [ { "uri": "...", "offset": 0, "length": 1024, "checksum": "..." } ],
+  "attachment_metadata": [ { "name": "...", "size": 0, "checksum": "..." } ],
+  "counts": { "memories": 0 }
+}
+```
+
+### 5.3 Compatibility
+
+- `hotmem snapshot`/`hydrate` keep flags; v2 directory is the new default.
+- Hydrate reads legacy single-file `swap.jsonl` (plain + stored-embedding,
+  per #25) unchanged — path heuristic: directory → v2, `.jsonl[.gz]` → legacy.
+- Manifest checksums verified on hydrate; mismatch is a hard error.
+- Deterministic ordering/hashing for identical input.
+
+## 6. Event Log
+
+### 6.1 Vocabulary
+
+`MemoryAdded`, `MemoryUpdated`, `MemoryMerged`, `MemoryArchived`,
+`SnapshotCreated`, `PromotionRequested`.
+
+### 6.2 Shape
+
+Each event: id, type, timestamp, target memory id(s), before/after payloads
+as needed, monotonic sequence number.
+
+### 6.3 Storage + replay
+
+- Append-only (SQLite table or JSONL under mount); no in-place
+  update/delete.
+- `GET /v1/events` with cursor + limit (tail-style).
+- Replay reconstructs memory state deterministically (recovery/sync, not the
+  hot read path).
+- A baseline snapshot can seed the log on first vNext boot (documented here,
+  implemented in #41).
+
+## 7. Promotion Lifecycle
+
+### 7.1 State machine
+
+```
+HOT ──► READY ──► PROMOTED ──► ARCHIVED
+```
+
+- Default state `HOT`.
+- `promotion_candidate` flag + heuristics (age, importance, tier, size) mark
+  `READY` without promoting.
+- `POST /v1/promote` transitions state and emits `PromotionRequested`; HotMem
+  records the transition, **EMOS performs the actual tier movement**.
+- Archive is a state, not deletion (v0.1 has no delete); archived memories
+  excluded from default search, retrievable via audit/full profiles.
+- Provenance preserved across all transitions.
+
+## 8. Hydration Profiles
+
+| Profile | Context | Metadata | Provenance | Files |
+|---|---|---|---|---|
+| agent | small/summarized, bounded | core only | none | none |
+| compact | minimal | minimal | none | none |
+| audit | full | full | full | refs only |
+| full | complete | full | full | refs + payload (lazy) |
+
+Default (no profile) == current v0.1 payload shape.
+
+## 9. API Extensions
+
+- `GET /v1/files` — list file references (uri, format, size, checksum,
+  referencing memory ids). Read-only.
+- `POST /v1/export` — JSONL and JSON (Arrow/Parquet future; unsupported
+  formats error explicitly). Export-only, no querying.
+- `GET /v1/memory/{id}` — full v2 record.
+- `POST /v1/promote` — promotion transition (EMOS performs movement).
+- `GET /v1/events` — append-only event tail (cursor + limit).
+- Hydrate gains `profile=`, `include_files=`, `include_provenance=`.
+
+## 10. Backwards Compatibility
+
+- v0.1 schema opens and serves without manual intervention (additive ALTERs).
+- Legacy `swap.jsonl` (plain + stored-embedding) hydrates identically.
+- Existing `/v1/add` and `/v1/search` payloads unchanged for callers that
+  don't set v2 fields.
+- FTS5 triggers + indexes remain functional.
+- No new runtime dependencies (stdlib only for M0/M1).
+
+## 11. Trade-offs
+
+1. **Reference vs copy.** File-backed memories reference (URI + offset +
+   length + checksum) rather than duplicate. Trade-off: hydration requires the
+   backing file present and checksum-stable; loss of the file means loss of
+   hydration, not loss of the memory record.
+2. **mmap vs explicit range reads.** mmap is fast for repeated access but
+   couples memory lifetime to file lifetime and risks SIGBUS on truncation.
+   Decision: range reads by default; mmap optional behind a flag for known
+   stable local files.
+3. **Event log growth.** Append-only log grows unboundedly. Trade-off:
+   replay/sync value vs storage cost. Decision: log is durable under the mount;
+   compaction (snapshot-seed + truncate) is a future concern, owned here as a
+   design note, not implemented in M0/M1.
+4. **Manifest cost.** v2 snapshot adds a manifest + per-file checksums vs the
+   single-file legacy format. Trade-off: portability/replay vs size. Decision:
+   directory format is the new default; legacy reader preserved so cost is
+   opt-in by choosing the new format.
+5. **`source` vs `source_uri`.** Keeping the legacy free-text `source` column
+   avoids a breaking rename but leaves two provenance-ish fields. Trade-off:
+   compat vs clarity. Decision: keep both; `source_uri` is canonical in v2,
+   `source` is legacy-superseded and documented as such.
+
+## 12. Roadmap (milestones → tickets)
+
+| Milestone | Ticket | Title |
+|---|---|---|
+| M0: Design | #35 | RFC: File-Aware Memory Sidecar (this doc) |
+| M1: Foundations | #36 | Memory Record v2 schema + provenance + migration |
+| M1: Foundations | #37 | Storage Adapter abstraction + local FS impl |
+| M2: File Awareness | #38 | File-backed memories (URI + range + checksum hydration) |
+| M2: File Awareness | #39 | Snapshot v2 directory format |
+| M3: Hydration + API | #40 | Hydration Profiles |
+| M3: Hydration + API | #43 | API extensions |
+| M4: Lifecycle | #41 | Append-only Event Log + /v1/events |
+| M4: Lifecycle | #42 | Promotion lifecycle |
+
+## 13. M0/M1 testing strategy (inherited by later milestones)
+
+- **#36:** migration opens v0.1 fixture DB → serves rows with defaults;
+  write/read round-trip preserves all v2 fields incl. provenance; legacy
+  callers behave identically to v0.1; full existing suite green.
+- **#37:** read, read_range (slice correctness vs full read), checksum
+  determinism + cache, unsupported-scheme error, range-beyond-EOF.
+- Shared: round-trip snapshot↔hydrate, legacy-format compat, event replay
+  determinism, range-read checksum verification (landed by their owning
+  tickets).

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -47,7 +47,23 @@ CREATE TABLE IF NOT EXISTS memories (
     metadata_json   TEXT DEFAULT '{{}}',
     content_hash    TEXT DEFAULT '',
     ttl_seconds     INTEGER,
-    created_at      TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+    created_at      TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    namespace       TEXT DEFAULT '',
+    tier            TEXT DEFAULT 'hot',
+    memory_type     TEXT DEFAULT 'fact',
+    source_uri      TEXT DEFAULT '',
+    source_format   TEXT DEFAULT '',
+    source_checksum TEXT DEFAULT '',
+    byte_offset     INTEGER,
+    byte_length     INTEGER,
+    updated_at      TEXT,
+    snapshot_id     TEXT DEFAULT '',
+    promotion_state TEXT DEFAULT 'HOT',
+    promotion_candidate INTEGER DEFAULT 0,
+    parent_memory   TEXT DEFAULT '',
+    related_memories TEXT DEFAULT '[]',
+    tags            TEXT DEFAULT '[]',
+    schema_version  INTEGER DEFAULT 1
 );
 CREATE INDEX IF NOT EXISTS idx_memories_identifier ON memories(identifier);
 CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories(content_hash);
@@ -94,6 +110,22 @@ class MemoryRecord:
     content_hash: str = ""
     ttl_seconds: int | None = None
     created_at: str | None = None
+    namespace: str = ""
+    tier: str = "hot"
+    memory_type: str = "fact"
+    source_uri: str = ""
+    source_format: str = ""
+    source_checksum: str = ""
+    byte_offset: int | None = None
+    byte_length: int | None = None
+    updated_at: str | None = None
+    snapshot_id: str = ""
+    promotion_state: str = "HOT"
+    promotion_candidate: int = 0
+    parent_memory: str = ""
+    related_memories: str = "[]"
+    tags: str = "[]"
+    schema_version: int = 1
 
 
 def _cosine_similarity(blob_a: bytes | None, blob_b: bytes | None) -> float | None:
@@ -145,6 +177,38 @@ class MemoryDB:
             self._conn.commit()
             _trace.info("migrate", "added ttl_seconds column")
 
+        _V2_COLUMNS: dict[str, str] = {
+            "namespace": "TEXT DEFAULT ''",
+            "tier": "TEXT DEFAULT 'hot'",
+            "memory_type": "TEXT DEFAULT 'fact'",
+            "source_uri": "TEXT DEFAULT ''",
+            "source_format": "TEXT DEFAULT ''",
+            "source_checksum": "TEXT DEFAULT ''",
+            "byte_offset": "INTEGER",
+            "byte_length": "INTEGER",
+            "updated_at": "TEXT",
+            "snapshot_id": "TEXT DEFAULT ''",
+            "promotion_state": "TEXT DEFAULT 'HOT'",
+            "promotion_candidate": "INTEGER DEFAULT 0",
+            "parent_memory": "TEXT DEFAULT ''",
+            "related_memories": "TEXT DEFAULT '[]'",
+            "tags": "TEXT DEFAULT '[]'",
+            "schema_version": "INTEGER DEFAULT 1",
+        }
+        added = []
+        for column, decl in _V2_COLUMNS.items():
+            if not _has_column(self._conn, "memories", column):
+                self._conn.execute(f"ALTER TABLE memories ADD COLUMN {column} {decl}")
+                added.append(column)
+        if added:
+            self._conn.commit()
+            _trace.info("migrate", "added v2 columns", detail={"columns": added})
+
+        current_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if current_version < 2:
+            self._conn.execute("PRAGMA user_version = 2")
+            self._conn.commit()
+
         try:
             self._conn.execute(
                 """CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_content_hash_unique
@@ -173,15 +237,35 @@ class MemoryDB:
         content_hash: str = "",
         ttl_seconds: int | None = None,
         created_at: str | None = None,
+        namespace: str = "",
+        tier: str = "hot",
+        memory_type: str = "fact",
+        source_uri: str = "",
+        source_format: str = "",
+        source_checksum: str = "",
+        byte_offset: int | None = None,
+        byte_length: int | None = None,
+        updated_at: str | None = None,
+        snapshot_id: str = "",
+        promotion_state: str = "HOT",
+        promotion_candidate: int = 0,
+        parent_memory: str = "",
+        related_memories: str = "[]",
+        tags: str = "[]",
+        schema_version: int = 1,
     ) -> None:
         """Insert a memory row."""
         self._conn.execute(
             """INSERT OR REPLACE INTO memories
             (id, identifier, fact_text, embedding, embedding_dim, embedding_model,
-             source, importance, metadata_json, content_hash, ttl_seconds, created_at)
+             source, importance, metadata_json, content_hash, ttl_seconds, created_at,
+             namespace, tier, memory_type, source_uri, source_format, source_checksum,
+             byte_offset, byte_length, updated_at, snapshot_id, promotion_state,
+             promotion_candidate, parent_memory, related_memories, tags, schema_version)
             VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )""",
             (
                 id,
@@ -196,6 +280,22 @@ class MemoryDB:
                 content_hash,
                 ttl_seconds,
                 created_at,
+                namespace,
+                tier,
+                memory_type,
+                source_uri,
+                source_format,
+                source_checksum,
+                byte_offset,
+                byte_length,
+                updated_at,
+                snapshot_id,
+                promotion_state,
+                promotion_candidate,
+                parent_memory,
+                related_memories,
+                tags,
+                schema_version,
             ),
         )
         self._conn.commit()
@@ -217,6 +317,22 @@ class MemoryDB:
                 record.content_hash,
                 record.ttl_seconds,
                 record.created_at,
+                record.namespace,
+                record.tier,
+                record.memory_type,
+                record.source_uri,
+                record.source_format,
+                record.source_checksum,
+                record.byte_offset,
+                record.byte_length,
+                record.updated_at,
+                record.snapshot_id,
+                record.promotion_state,
+                record.promotion_candidate,
+                record.parent_memory,
+                record.related_memories,
+                record.tags,
+                record.schema_version,
             )
             for record in records
         ]
@@ -226,10 +342,14 @@ class MemoryDB:
         cursor = self._conn.executemany(
             """INSERT OR IGNORE INTO memories
             (id, identifier, fact_text, embedding, embedding_dim, embedding_model,
-             source, importance, metadata_json, content_hash, ttl_seconds, created_at)
+             source, importance, metadata_json, content_hash, ttl_seconds, created_at,
+             namespace, tier, memory_type, source_uri, source_format, source_checksum,
+             byte_offset, byte_length, updated_at, snapshot_id, promotion_state,
+             promotion_candidate, parent_memory, related_memories, tags, schema_version)
             VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )""",
             rows,
         )
@@ -279,16 +399,18 @@ class MemoryDB:
 
     def all_rows(self, *, include_embedding: bool = False) -> list[dict[str, Any]]:
         """Return all memory rows as dicts (for snapshot export)."""
-        query = (
-            """SELECT id, identifier, fact_text, embedding_dim, embedding_model,
-                      source, importance, metadata_json, content_hash, ttl_seconds, created_at,
-                      embedding
-               FROM memories"""
-            if include_embedding
-            else """SELECT id, identifier, fact_text, embedding_dim, embedding_model,
-                           source, importance, metadata_json, content_hash, ttl_seconds, created_at
-                    FROM memories"""
+        v2_cols = (
+            "namespace, tier, memory_type, source_uri, source_format, "
+            "source_checksum, byte_offset, byte_length, updated_at, snapshot_id, "
+            "promotion_state, promotion_candidate, parent_memory, "
+            "related_memories, tags, schema_version"
         )
+        base = (
+            "id, identifier, fact_text, embedding_dim, embedding_model, source, "
+            "importance, metadata_json, content_hash, ttl_seconds, created_at"
+        )
+        tail = ", embedding" if include_embedding else ""
+        query = f"SELECT {base}, {v2_cols}{tail} FROM memories"
         rows = self._conn.execute(query).fetchall()
         return [dict(r) for r in rows]
 

--- a/src/hotmem/storage/__init__.py
+++ b/src/hotmem/storage/__init__.py
@@ -1,0 +1,65 @@
+"""HotMem storage adapters.
+
+Purpose:
+    Abstract file/object access behind a single interface so HotMem can
+    reference large data (file ranges) without duplicating it. HotMem only
+    understands the abstraction; EMOS owns distributed storage.
+
+Interface:
+    StorageAdapter (Protocol): read, read_range, exists, metadata, checksum
+
+Extension:
+    Add new adapters (S3, HDFS, Azure, GCS) by registering a scheme in the
+    ADAPTERS registry below. Distributed/object storage is owned by EMOS,
+    not HotMem.
+"""
+
+from __future__ import annotations
+
+from .base import StorageAdapter, StorageMetadata
+from .local import LocalFilesystemAdapter
+
+__all__ = [
+    "StorageAdapter",
+    "StorageMetadata",
+    "LocalFilesystemAdapter",
+    "get_adapter",
+    "UnsupportedSchemeError",
+]
+
+
+class UnsupportedSchemeError(ValueError):
+    """Raised when a URI scheme is not handled by any HotMem adapter.
+
+    Distributed/object storage (s3://, hdfs://, abfs://, gcs://, ...) is
+    owned by EMOS, not HotMem.
+    """
+
+
+ADAPTERS: dict[str, StorageAdapter] = {
+    "": LocalFilesystemAdapter(),
+    "file": LocalFilesystemAdapter(),
+}
+
+
+def get_adapter(uri: str) -> StorageAdapter:
+    """Return the adapter for a URI's scheme, or raise UnsupportedSchemeError.
+
+    Bare paths and file:// URIs resolve to the local filesystem adapter.
+    Unknown schemes raise an explicit error pointing to EMOS ownership.
+    """
+    scheme = _scheme(uri)
+    adapter = ADAPTERS.get(scheme)
+    if adapter is None:
+        raise UnsupportedSchemeError(
+            f"unsupported URI scheme {scheme!r} for {uri!r}; "
+            "distributed/object storage is owned by EMOS, not HotMem"
+        )
+    return adapter
+
+
+def _scheme(uri: str) -> str:
+    """Return the lowercase scheme of a URI, or '' for a bare path."""
+    if "://" in uri:
+        return uri.split("://", 1)[0].lower()
+    return ""

--- a/src/hotmem/storage/base.py
+++ b/src/hotmem/storage/base.py
@@ -1,0 +1,45 @@
+"""Storage adapter interface.
+
+HotMem references large data (URI + offset + length + checksum) instead of
+duplicating it. This protocol is the seam between HotMem and any backing
+store. The local filesystem adapter is the only built-in implementation;
+distributed/object adapters are owned by EMOS.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypedDict, runtime_checkable
+
+
+class StorageMetadata(TypedDict):
+    """Metadata for a backing object."""
+
+    uri: str
+    size: int
+    mtime: float
+    format: str
+
+
+@runtime_checkable
+class StorageAdapter(Protocol):
+    """Read access to a backing store without copying entire datasets."""
+
+    def read(self, uri: str) -> bytes:
+        """Read the full contents of a backing object."""
+        ...
+
+    def read_range(self, uri: str, offset: int, length: int) -> bytes:
+        """Read a byte range [offset, offset + length) without full-file load."""
+        ...
+
+    def exists(self, uri: str) -> bool:
+        """Return True if the backing object exists."""
+        ...
+
+    def metadata(self, uri: str) -> StorageMetadata:
+        """Return size, mtime, and inferred format for a backing object."""
+        ...
+
+    def checksum(self, uri: str) -> str:
+        """Return a sha256 hex digest of the backing object's contents."""
+        ...

--- a/src/hotmem/storage/local.py
+++ b/src/hotmem/storage/local.py
@@ -1,0 +1,87 @@
+"""Local filesystem storage adapter.
+
+Handles file:// URIs and bare paths. Range reads use seek + read (no
+full-file load); checksums are sha256 with an LRU cache; metadata infers
+format from the file extension. An optional mmap path is available for
+known-stable local files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import mmap
+from functools import lru_cache
+from pathlib import Path
+
+from .base import StorageMetadata
+
+_FORMAT_MAP: dict[str, str] = {
+    ".pdf": "pdf",
+    ".txt": "txt",
+    ".json": "json",
+    ".jsonl": "jsonl",
+    ".csv": "csv",
+    ".parquet": "parquet",
+    ".md": "markdown",
+    ".html": "html",
+    ".xml": "xml",
+    ".png": "png",
+    ".jpg": "jpeg",
+    ".jpeg": "jpeg",
+}
+
+
+def _to_path(uri: str) -> Path:
+    """Resolve a file:// URI or bare path to a filesystem Path."""
+    if uri.startswith("file://"):
+        return Path(uri[len("file://") :])
+    return Path(uri)
+
+
+class LocalFilesystemAdapter:
+    """Read-only local filesystem adapter for file:// URIs and bare paths."""
+
+    def read(self, uri: str) -> bytes:
+        return _to_path(uri).read_bytes()
+
+    def read_range(self, uri: str, offset: int, length: int) -> bytes:
+        if offset < 0:
+            raise ValueError(f"offset must be non-negative, got {offset}")
+        if length < 0:
+            raise ValueError(f"length must be non-negative, got {length}")
+        path = _to_path(uri)
+        with open(path, "rb") as f:
+            f.seek(offset)
+            return f.read(length)
+
+    def exists(self, uri: str) -> bool:
+        return _to_path(uri).exists()
+
+    def metadata(self, uri: str) -> StorageMetadata:
+        path = _to_path(uri)
+        stat = path.stat()
+        return StorageMetadata(
+            uri=uri,
+            size=stat.st_size,
+            mtime=stat.st_mtime,
+            format=_FORMAT_MAP.get(path.suffix.lower(), "unknown"),
+        )
+
+    def checksum(self, uri: str) -> str:
+        return _checksum(_to_path(uri))
+
+    def mmap_read(self, uri: str) -> bytes:
+        """Memory-map a backing file. Caller must ensure file stability."""
+        path = _to_path(uri)
+        with open(path, "rb") as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as m:
+            return m[:]
+
+
+@lru_cache(maxsize=256)
+def _checksum(path: Path) -> str:
+    """Cached sha256 of a file path. Cache keyed on Path (not URI)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -160,3 +160,128 @@ def test_existing_db_gets_ttl_column(tmp_path):
         assert "ttl_seconds" in columns
     finally:
         db.close()
+
+
+def test_v2_migration_opens_v01_db(tmp_path):
+    db_path = tmp_path / "v01.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE memories (
+            id TEXT PRIMARY KEY,
+            identifier TEXT NOT NULL,
+            fact_text TEXT NOT NULL,
+            embedding BLOB,
+            embedding_dim INTEGER,
+            embedding_model TEXT DEFAULT '',
+            source TEXT DEFAULT '',
+            importance REAL DEFAULT 0.5,
+            metadata_json TEXT DEFAULT '{}',
+            content_hash TEXT DEFAULT '',
+            ttl_seconds INTEGER,
+            created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        )"""
+    )
+    blob = pack_embedding(embed_text("legacy fact"))
+    conn.execute(
+        """INSERT INTO memories (id, identifier, fact_text, embedding)
+           VALUES ('legacy1', 'x', 'legacy fact', ?)""",
+        (blob,),
+    )
+    conn.commit()
+    conn.close()
+
+    db = MemoryDB(db_path)
+    try:
+        columns = {row["name"] for row in db._conn.execute("PRAGMA table_info(memories)")}
+        for col in (
+            "namespace",
+            "tier",
+            "memory_type",
+            "source_uri",
+            "source_format",
+            "source_checksum",
+            "byte_offset",
+            "byte_length",
+            "updated_at",
+            "snapshot_id",
+            "promotion_state",
+            "promotion_candidate",
+            "parent_memory",
+            "related_memories",
+            "tags",
+            "schema_version",
+        ):
+            assert col in columns, f"missing v2 column: {col}"
+
+        version = db._conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 2
+
+        row = db.all_rows()[0]
+        assert row["id"] == "legacy1"
+        assert row["promotion_state"] == "HOT"
+        assert row["schema_version"] == 1
+        assert row["tags"] == "[]"
+        assert db.count() == 1
+    finally:
+        db.close()
+
+
+def test_v2_fields_roundtrip(tmp_db: MemoryDB):
+    blob = pack_embedding(embed_text("provenance fact"))
+    tmp_db.insert(
+        id="v2-1",
+        identifier="ns-a",
+        fact_text="provenance fact",
+        embedding=blob,
+        namespace="contracts",
+        tier="hot",
+        memory_type="fact",
+        source_uri="file:///data/contract.pdf",
+        source_format="pdf",
+        source_checksum="sha256:abc123",
+        byte_offset=4096,
+        byte_length=128,
+        updated_at="2026-07-01T00:00:00Z",
+        snapshot_id="snap-1",
+        promotion_state="READY",
+        promotion_candidate=1,
+        parent_memory="parent-1",
+        related_memories='["m1","m2"]',
+        tags='["legal","contract"]',
+        schema_version=2,
+    )
+
+    row = tmp_db.all_rows()[0]
+    assert row["namespace"] == "contracts"
+    assert row["tier"] == "hot"
+    assert row["memory_type"] == "fact"
+    assert row["source_uri"] == "file:///data/contract.pdf"
+    assert row["source_format"] == "pdf"
+    assert row["source_checksum"] == "sha256:abc123"
+    assert row["byte_offset"] == 4096
+    assert row["byte_length"] == 128
+    assert row["updated_at"] == "2026-07-01T00:00:00Z"
+    assert row["snapshot_id"] == "snap-1"
+    assert row["promotion_state"] == "READY"
+    assert row["promotion_candidate"] == 1
+    assert row["parent_memory"] == "parent-1"
+    assert row["related_memories"] == '["m1","m2"]'
+    assert row["tags"] == '["legal","contract"]'
+    assert row["schema_version"] == 2
+
+
+def test_v2_fields_default_when_unset(tmp_db: MemoryDB):
+    blob = pack_embedding(embed_text("plain fact"))
+    tmp_db.insert(id="d1", identifier="x", fact_text="plain fact", embedding=blob)
+
+    row = tmp_db.all_rows()[0]
+    assert row["namespace"] == ""
+    assert row["tier"] == "hot"
+    assert row["memory_type"] == "fact"
+    assert row["source_uri"] == ""
+    assert row["promotion_state"] == "HOT"
+    assert row["promotion_candidate"] == 0
+    assert row["tags"] == "[]"
+    assert row["schema_version"] == 1
+    assert row["byte_offset"] is None
+    assert row["byte_length"] is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,108 @@
+"""Tests for hotmem.storage — adapter abstraction and local FS impl."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from hotmem.storage import (
+    LocalFilesystemAdapter,
+    UnsupportedSchemeError,
+    get_adapter,
+)
+
+
+@pytest.fixture
+def adapter() -> LocalFilesystemAdapter:
+    return LocalFilesystemAdapter()
+
+
+@pytest.fixture
+def data_file(tmp_path):
+    path = tmp_path / "data.txt"
+    path.write_bytes(b"0123456789abcdef")
+    return path
+
+
+def _uri(path) -> str:
+    return f"file://{path}"
+
+
+def test_read_full(adapter, data_file):
+    assert adapter.read(_uri(data_file)) == b"0123456789abcdef"
+    assert adapter.read(str(data_file)) == b"0123456789abcdef"
+
+
+def test_read_range_matches_slice(adapter, data_file):
+    uri = _uri(data_file)
+    assert adapter.read_range(uri, 4, 8) == b"456789ab"
+    assert adapter.read_range(uri, 0, 4) == b"0123"
+    assert adapter.read_range(uri, 12, 4) == b"cdef"
+
+
+def test_read_range_does_not_blow_past_eof(adapter, data_file):
+    assert adapter.read_range(_uri(data_file), 14, 100) == b"ef"
+    assert adapter.read_range(_uri(data_file), 16, 4) == b""
+
+
+def test_read_range_rejects_negative(adapter, data_file):
+    with pytest.raises(ValueError):
+        adapter.read_range(_uri(data_file), -1, 4)
+    with pytest.raises(ValueError):
+        adapter.read_range(_uri(data_file), 0, -1)
+
+
+def test_exists(adapter, data_file, tmp_path):
+    assert adapter.exists(_uri(data_file))
+    assert adapter.exists(str(data_file))
+    assert not adapter.exists(str(tmp_path / "missing.txt"))
+
+
+def test_metadata(adapter, data_file):
+    md = adapter.metadata(_uri(data_file))
+    assert md["uri"] == _uri(data_file)
+    assert md["size"] == 16
+    assert md["format"] == "txt"
+    assert isinstance(md["mtime"], float)
+
+
+def test_checksum_is_sha256_and_stable(adapter, data_file):
+    expected = hashlib.sha256(data_file.read_bytes()).hexdigest()
+    assert adapter.checksum(_uri(data_file)) == expected
+    assert adapter.checksum(str(data_file)) == expected
+    assert adapter.checksum(_uri(data_file)) == adapter.checksum(str(data_file))
+
+
+def test_checksum_distinct_for_different_files(adapter, tmp_path):
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    a.write_bytes(b"aaa")
+    b.write_bytes(b"bbb")
+    assert adapter.checksum(str(a)) != adapter.checksum(str(b))
+
+
+def test_get_adapter_resolves_local_schemes(data_file):
+    assert isinstance(get_adapter(_uri(data_file)), LocalFilesystemAdapter)
+    assert isinstance(get_adapter(str(data_file)), LocalFilesystemAdapter)
+
+
+def test_get_adapter_rejects_unsupported_scheme():
+    with pytest.raises(UnsupportedSchemeError, match="EMOS"):
+        get_adapter("s3://bucket/key")
+
+
+def test_get_adapter_rejects_each_remote_scheme():
+    for scheme in ("hdfs", "abfs", "gcs", "gs"):
+        with pytest.raises(UnsupportedSchemeError):
+            get_adapter(f"{scheme}://x/y")
+
+
+def test_mmap_read_matches_file(adapter, data_file):
+    assert adapter.mmap_read(_uri(data_file)) == b"0123456789abcdef"
+
+
+def test_adapter_is_runtime_checkable():
+    from hotmem.storage.base import StorageAdapter
+
+    assert isinstance(LocalFilesystemAdapter(), StorageAdapter)


### PR DESCRIPTION
## Summary

First slice of HotMem vNext (file-aware memory sidecar), delivering the M0 (Design) and M1 (Foundations) milestones. Planning-first, additive, no breaking changes.

| Commit | Issue | Scope |
|---|---|---|
| `720fb22` | #35 | RFC design doc: record v2 field mapping, storage adapter interface, snapshot v2 layout, event log vocabulary, promotion state machine, hydration profiles, API extensions, compat strategy, trade-offs, roadmap |
| `9ac94f2` | #36 | Memory Record v2: 15 additive columns + migration + `PRAGMA user_version` bump; `MemoryRecord`/insert/insert_many_ignore/all_rows extended |
| `123a824` | #37 | Storage adapter Protocol + `LocalFilesystemAdapter` (range reads, cached sha256, metadata) + scheme registry rejecting remote schemes as EMOS-owned |

## What changed

- **docs/vnext/0001-file-aware-sidecar.md** — design doc (no code).
- **src/hotmem/db.py** — additive schema/migration/dataclass changes; legacy v0.1 DBs open unchanged with safe defaults.
- **src/hotmem/storage/** — new package (base Protocol, local FS impl, scheme registry). No integration into db/server yet (that is #38).
- **tests/** — +13 storage tests, +3 db migration/roundtrip tests.

## Verification

- `ruff check` clean, `ruff format` clean
- Full suite: **83 passed** (was 70; +13 storage)
- Zero new runtime dependencies (stdlib only)

## Compatibility

- v0.1 schema opens and serves without manual intervention (additive ALTERs, idempotent migration).
- Existing `/v1/add` and `/v1/search` payloads unchanged for callers that don't set v2 fields.
- FTS5 triggers + indexes remain functional.
- `fact_text` column name and legacy `source` column retained.

## Out of scope (later milestones)

- File-backed memory wiring (#38, M2)
- Snapshot v2 directory format (#39, M2)
- Hydration profiles (#40, M3), API extensions (#43, M3)
- Event log (#41, M4), promotion lifecycle (#42, M4)

Refs #35 #36 #37

Closes #35, Closes #36, Closes #37