### PR TITLE
Phase 3 DX: Docker image + Playground TUI + OpenAPI/docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Build artifacts
+dist/
+*.egg-info/
+__pycache__/
+*.pyc
+
+# Version control
+.git/
+.github/
+.gitignore
+
+# Tests and dev tooling
+tests/
+.pytest_cache/
+.ruff_cache/
+.venv/
+
+# Docs (built in CI, not needed in image)
+docs/
+site/
+mkdocs.yml
+
+# Local data
+data/
+hotmem/
+*.sqlite
+*.jsonl
+*.jsonl.gz

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and publish"
+        required: true
+        type: string
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Derive image tags
+        id: tags
+        run: |
+          REF="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          VERSION="${REF#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: ${{ vars.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/knowguard-ai/hotmem:latest
+            ghcr.io/knowguard-ai/hotmem:${{ steps.tags.outputs.version }}
+            ${{ vars.DOCKERHUB_USERNAME && format('knowguard/hotmem:latest') || '' }}
+            ${{ vars.DOCKERHUB_USERNAME && format('knowguard/hotmem:{0}', steps.tags.outputs.version) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv pip install -e ".[docs]"
+      - name: Export OpenAPI spec
+        run: |
+          uv run hotmem openapi --output docs/openapi.json
+      - name: Build site
+        run: uv run mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
-# ── Builder ──────────────────────────────────────────────────────────────────
-FROM python:3.12-slim AS builder
+# ── Builder (alpine — musl-compatible wheels) ───────────────────────────────
+FROM python:3.12-alpine AS builder
 
 ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1
+
+RUN apk add --no-cache build-base
 
 WORKDIR /build
 
@@ -16,8 +18,8 @@ RUN pip install --upgrade pip && \
     pip wheel --no-deps --wheel-dir /wheels . && \
     pip wheel --wheel-dir /wheels click fastapi httpx uvicorn
 
-# ── Runtime ──────────────────────────────────────────────────────────────────
-FROM python:3.12-slim AS runtime
+# ── Runtime (alpine — small footprint) ──────────────────────────────────────
+FROM python:3.12-alpine AS runtime
 
 LABEL org.opencontainers.image.title="HotMem" \
       org.opencontainers.image.description="Local-first memory sidecar for agent applications" \
@@ -27,12 +29,15 @@ LABEL org.opencontainers.image.title="HotMem" \
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-RUN groupadd --system --gid 1001 hotmem && \
-    useradd --system --uid 1001 --gid hotmem --create-home hotmem && \
+RUN addgroup --system --gid 1001 hotmem && \
+    adduser --system --uid 1001 --ingroup hotmem --no-create-home hotmem && \
     mkdir -p /data && chown hotmem:hotmem /data
 
 COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir /wheels/*.whl && rm -rf /wheels
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir /wheels/*.whl && \
+    rm -rf /wheels && \
+    pip cache purge
 
 USER hotmem
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.7
+
+# ── Builder ──────────────────────────────────────────────────────────────────
+FROM python:3.12-slim AS builder
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /build
+
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+RUN pip install --upgrade pip && \
+    pip wheel --no-deps --wheel-dir /wheels . && \
+    pip wheel --wheel-dir /wheels click fastapi httpx uvicorn
+
+# ── Runtime ──────────────────────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+LABEL org.opencontainers.image.title="HotMem" \
+      org.opencontainers.image.description="Local-first memory sidecar for agent applications" \
+      org.opencontainers.image.source="https://github.com/KnowGuard-AI/HotMem" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN groupadd --system --gid 1001 hotmem && \
+    useradd --system --uid 1001 --gid hotmem --create-home hotmem && \
+    mkdir -p /data && chown hotmem:hotmem /data
+
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir /wheels/*.whl && rm -rf /wheels
+
+USER hotmem
+VOLUME ["/data"]
+EXPOSE 8711
+
+ENTRYPOINT ["hotmem", "serve", "--mount", "/data", "--host", "0.0.0.0", "--port", "8711"]

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,83 @@
+# API Reference
+
+All endpoints are under `/v1`. Default: `http://127.0.0.1:8711`
+
+Interactive Swagger UI is available at `http://127.0.0.1:8711/docs` when the server is running.
+
+## Health
+
+```http
+GET /v1/health
+```
+
+Returns server status, memory count, DB path, and uptime.
+
+## Add memory
+
+```http
+POST /v1/add
+Content-Type: application/json
+
+{
+  "identifier": "user",
+  "fact": "prefers dark mode",
+  "source": "chat",
+  "importance": 0.5,
+  "metadata": {},
+  "ttl_seconds": null
+}
+```
+
+Returns `memory_id`, `content_hash`, and `trace_ms`.
+
+## Search
+
+```http
+POST /v1/search
+Content-Type: application/json
+
+{
+  "query": "what theme does the user like",
+  "top_k": 5,
+  "max_chars": null
+}
+```
+
+Returns ranked `memories` (LLM-ready message objects) with `count` and `trace_ms`.
+
+## Hydrate
+
+```http
+POST /v1/hydrate
+Content-Type: application/json
+
+{
+  "file": "swap.jsonl"
+}
+```
+
+Loads memories from a JSONL or JSONL.GZ swap file. Deduplicates by `content_hash`.
+
+## Snapshot
+
+```http
+POST /v1/snapshot
+Content-Type: application/json
+
+{
+  "file": "swap.jsonl"
+}
+```
+
+Exports all memories to a JSONL or JSONL.GZ swap file.
+
+## OpenAPI spec
+
+Export the machine-readable spec:
+
+```bash
+hotmem openapi --output openapi.json
+hotmem openapi --output openapi.yaml --format yaml
+```
+
+Or fetch it from a running server: `GET /openapi.json`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,61 @@
+# CLI
+
+```bash
+hotmem serve --port 8711 --mount ./data/hotmem
+hotmem serve --db ./my.sqlite
+hotmem serve --host 0.0.0.0 --port 8711
+hotmem hydrate --file swap.jsonl --db ./my.sqlite
+hotmem snapshot --file swap.jsonl --db ./my.sqlite
+hotmem status
+hotmem openapi --output openapi.json
+hotmem openapi --output openapi.yaml --format yaml
+```
+
+## Commands
+
+### `serve`
+
+Start the HotMem sidecar server.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--port` | 8711 | Port to listen on |
+| `--mount` | — | Mount directory path |
+| `--db` | — | Explicit database path |
+| `--host` | 127.0.0.1 | Host to bind to |
+
+### `hydrate`
+
+Load a swap file into the database.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--file` | swap.jsonl | Swap file path |
+| `--db` | required | Database path |
+
+### `snapshot`
+
+Export database memories to a swap file.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--file` | swap.jsonl | Output swap file path |
+| `--db` | required | Database path |
+
+### `status`
+
+Check if a HotMem server is running.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--port` | 8711 | Port to check |
+| `--host` | 127.0.0.1 | Host to check |
+
+### `openapi`
+
+Export the OpenAPI specification.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--output` / `-o` | stdout | Output file path |
+| `--format` | json | Output format (json or yaml) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+# HotMem
+
+A **local-first memory sidecar** for agent applications. One SQLite DB. One port: `8711`.
+
+HotMem provides fast, queryable working memory with hybrid vector + keyword search. Store facts, retrieve them ranked, and get back LLM-ready message objects you can stitch directly into prompts.
+
+## 30-second quickstart
+
+```bash
+pip install hotmem
+hotmem serve --mount ./hotmem
+```
+
+In another terminal:
+
+```bash
+# Add a memory
+curl -X POST http://127.0.0.1:8711/v1/add \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "user", "fact": "prefers dark mode"}'
+
+# Search
+curl -X POST http://127.0.0.1:8711/v1/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "what theme does the user like"}'
+```
+
+## Why HotMem?
+
+- **Local-first** — your data stays in a SQLite file. No cloud, no API keys.
+- **Extremely lightweight** — stdlib-only core, no transformers, no GPU.
+- **Deterministic** — same input produces same output, every time.
+- **Embeddable** — runs as a sidecar (HTTP) or in-process (Python import).
+- **Language agnostic** — any HTTP client works.
+
+## Links
+
+- [Quickstart](quickstart.md)
+- [API Reference](api.md)
+- [CLI](cli.md)
+- [GitHub](https://github.com/KnowGuard-AI/HotMem)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+## Install
+
+```bash
+pip install hotmem
+# or
+uv pip install hotmem
+```
+
+Supports Python 3.11, 3.12, 3.13, and 3.14.
+
+## Start the server
+
+```bash
+# Start with a mount directory (portable memory)
+hotmem serve --mount ./hotmem
+
+# Or just start (uses temp DB)
+hotmem serve
+```
+
+## Add and search memories
+
+```bash
+# Add a memory
+curl -X POST http://127.0.0.1:8711/v1/add \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "project", "fact": "uses FastAPI and SQLite"}'
+
+# Search
+curl -X POST http://127.0.0.1:8711/v1/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "what stack does the project use"}'
+```
+
+## Portable memory (snapshots)
+
+```bash
+# Export to a swap file
+hotmem snapshot --file swap.jsonl --db ./hotmem/hotmem.sqlite
+
+# Hydrate on another machine
+hotmem hydrate --file swap.jsonl --db ./my.sqlite
+```
+
+## Use the Python client
+
+```python
+from hotmem.client import HotMemClient
+
+client = HotMemClient("http://127.0.0.1:8711")
+client.add(identifier="user", fact="likes Rust")
+results = client.search(query="programming preferences")
+```
+
+## Docker
+
+```bash
+docker run -p 8711:8711 -v ./data:/data knowguard/hotmem
+```
+
+See [CLI](cli.md) for the full command reference and [API Reference](api.md) for endpoints.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,47 @@
+site_name: HotMem
+site_description: Local-first memory sidecar for agent applications
+site_url: https://knowguard-ai.github.io/HotMem
+repo_url: https://github.com/KnowGuard-AI/HotMem
+repo_name: KnowGuard-AI/HotMem
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - content.code.copy
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - API Reference: api.md
+  - CLI: cli.md
+  - Architecture:
+      - vNext Design: vnext/0001-file-aware-sidecar.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ Repository = "https://github.com/KnowGuard-AI/HotMem"
 mcp = [
     "mcp>=1.0,<2",
 ]
+docs = [
+    "mkdocs>=1.6,<2",
+    "mkdocs-material>=9.5,<10",
+    "pyyaml>=6.0,<7",
+]
 dev = [
     "pytest>=9,<10",
     "pytest-cov>=6,<7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Repository = "https://github.com/KnowGuard-AI/HotMem"
 mcp = [
     "mcp>=1.0,<2",
 ]
+playground = [
+    "rich>=13.7,<14",
+]
 docs = [
     "mkdocs>=1.6,<2",
     "mkdocs-material>=9.5,<10",

--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -200,3 +200,18 @@ def openapi(output: str | None, fmt: str):
             click.echo(yaml.dump(spec, sort_keys=False, default_flow_style=False))
         else:
             click.echo(json.dumps(spec, indent=2))
+
+
+@main.command()
+@click.option("--db", "db_path", default=None, type=click.Path(), help="Database file path.")
+@click.option("--url", default=None, help="Running server URL (e.g. http://127.0.0.1:8711).")
+def playground(db_path: str | None, url: str | None):
+    """Interactive terminal UI for add/search/inspect."""
+    from hotmem.playground import run_playground
+
+    try:
+        run_playground(db_path=db_path, url=url)
+    except ImportError as err:
+        raise click.ClickException(str(err)) from err
+    except ValueError as err:
+        raise click.ClickException(str(err)) from err

--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -14,6 +14,7 @@ Extension: add new subcommands (e.g. `hotmem inspect`, `hotmem gc`) here.
 
 from __future__ import annotations
 
+import json
 import tempfile
 
 import click
@@ -163,3 +164,39 @@ def status(port: int, host: str):
     except httpx.ConnectError as err:
         click.echo(f"No HotMem server found at {url}", err=True)
         raise SystemExit(1) from err
+
+
+@main.command()
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    type=click.Path(),
+    help="Output file path. If omitted, print to stdout.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "yaml"]),
+    default="json",
+    help="Output format.",
+)
+def openapi(output: str | None, fmt: str):
+    """Export the OpenAPI specification."""
+    from hotmem.openapi import dump_openapi, export_openapi
+
+    if output:
+        path = dump_openapi(output, fmt=fmt)
+        click.echo(f"OpenAPI spec written to {path}")
+    else:
+        spec = export_openapi()
+        if fmt == "yaml":
+            try:
+                import yaml
+            except ImportError as err:
+                raise click.ClickException(
+                    "YAML output requires PyYAML. Use --format json instead."
+                ) from err
+            click.echo(yaml.dump(spec, sort_keys=False, default_flow_style=False))
+        else:
+            click.echo(json.dumps(spec, indent=2))

--- a/src/hotmem/client.py
+++ b/src/hotmem/client.py
@@ -76,6 +76,21 @@ class HotMemClient:
         resp.raise_for_status()
         return resp.json()["memories"]
 
+    def list(
+        self,
+        identifier: str,
+        *,
+        order: str = "asc",
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return memories for an identifier in created_at order."""
+        resp = self._client.get(
+            "/v1/memories",
+            params={"identifier": identifier, "order": order, "limit": limit},
+        )
+        resp.raise_for_status()
+        return resp.json()["memories"]
+
     def hydrate(self, file: str | None = None) -> dict[str, Any]:
         """Trigger swap file hydration."""
         payload: dict[str, Any] = {}
@@ -153,6 +168,21 @@ class AsyncHotMemClient:
         if max_chars is not None:
             payload["max_chars"] = max_chars
         resp = await self._client.post("/v1/search", json=payload)
+        resp.raise_for_status()
+        return resp.json()["memories"]
+
+    async def list(
+        self,
+        identifier: str,
+        *,
+        order: str = "asc",
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return memories for an identifier in created_at order."""
+        resp = await self._client.get(
+            "/v1/memories",
+            params={"identifier": identifier, "order": order, "limit": limit},
+        )
         resp.raise_for_status()
         return resp.json()["memories"]
 

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -24,6 +24,7 @@ import math
 import re
 import sqlite3
 import struct
+import threading
 from collections.abc import Iterable
 from contextlib import suppress
 from dataclasses import dataclass
@@ -34,6 +35,98 @@ from hotmem.embed import EMBEDDING_DIM
 from hotmem.trace import get_tracer
 
 _trace = get_tracer("db")
+
+# Single source of truth for the memories table column order. Drives INSERT
+# statement generation and SQLite-to-SQLite import projection so the three
+# write paths cannot drift.
+_MEMORY_COLUMNS: tuple[str, ...] = (
+    "id",
+    "identifier",
+    "fact_text",
+    "embedding",
+    "embedding_dim",
+    "embedding_model",
+    "source",
+    "importance",
+    "metadata_json",
+    "content_hash",
+    "ttl_seconds",
+    "created_at",
+    "namespace",
+    "tier",
+    "memory_type",
+    "source_uri",
+    "source_format",
+    "source_checksum",
+    "byte_offset",
+    "byte_length",
+    "updated_at",
+    "snapshot_id",
+    "promotion_state",
+    "promotion_candidate",
+    "parent_memory",
+    "related_memories",
+    "tags",
+    "schema_version",
+)
+
+# SQL default expressions for optional columns, used when projecting rows from
+# a source DB that lacks them (v0.1 schema). Required columns (id, identifier,
+# fact_text, embedding) have no default and must exist in the source.
+_COLUMN_DEFAULTS: dict[str, str] = {
+    "embedding_dim": str(EMBEDDING_DIM),
+    "embedding_model": "''",
+    "source": "''",
+    "importance": "0.5",
+    "metadata_json": "'{}'",
+    "content_hash": "''",
+    "ttl_seconds": "NULL",
+    "created_at": "strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
+    "namespace": "''",
+    "tier": "'hot'",
+    "memory_type": "'fact'",
+    "source_uri": "''",
+    "source_format": "''",
+    "source_checksum": "''",
+    "byte_offset": "NULL",
+    "byte_length": "NULL",
+    "updated_at": "NULL",
+    "snapshot_id": "''",
+    "promotion_state": "'HOT'",
+    "promotion_candidate": "0",
+    "parent_memory": "''",
+    "related_memories": "'[]'",
+    "tags": "'[]'",
+    "schema_version": "1",
+}
+
+
+# TTL-live predicate — single source of truth so search and list agree on what
+# "expired" means. `alias` is "" for the unqualified table or "m." for joins.
+def _ttl_live(alias: str = "") -> str:
+    return (
+        f"({alias}ttl_seconds IS NULL OR "
+        f"(strftime('%s', 'now') - strftime('%s', {alias}created_at)) < {alias}ttl_seconds)"
+    )
+
+
+def _insert_placeholders() -> str:
+    """Build the VALUES placeholder list, with COALESCE on created_at."""
+    return ", ".join(
+        "COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))" if c == "created_at" else "?"
+        for c in _MEMORY_COLUMNS
+    )
+
+
+_INSERT_OR_REPLACE_SQL = (
+    f"INSERT OR REPLACE INTO memories ({', '.join(_MEMORY_COLUMNS)}) "
+    f"VALUES ({_insert_placeholders()})"
+)
+_INSERT_OR_IGNORE_SQL = (
+    f"INSERT OR IGNORE INTO memories ({', '.join(_MEMORY_COLUMNS)}) "
+    f"VALUES ({_insert_placeholders()})"
+)
+
 
 _SCHEMA = f"""
 CREATE TABLE IF NOT EXISTS memories (
@@ -67,6 +160,7 @@ CREATE TABLE IF NOT EXISTS memories (
     schema_version  INTEGER DEFAULT 1
 );
 CREATE INDEX IF NOT EXISTS idx_memories_identifier ON memories(identifier);
+CREATE INDEX IF NOT EXISTS idx_memories_identifier_created ON memories(identifier, created_at);
 CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories(content_hash);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
@@ -160,6 +254,7 @@ class MemoryDB:
 
     def __init__(self, db_path: str | Path) -> None:
         self.db_path = str(db_path)
+        self._lock = threading.Lock()
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -256,104 +351,50 @@ class MemoryDB:
         schema_version: int = 1,
     ) -> None:
         """Insert a memory row."""
+        values = {
+            "id": id,
+            "identifier": identifier,
+            "fact_text": fact_text,
+            "embedding": embedding,
+            "embedding_dim": embedding_dim,
+            "embedding_model": embedding_model,
+            "source": source,
+            "importance": importance,
+            "metadata_json": metadata_json,
+            "content_hash": content_hash,
+            "ttl_seconds": ttl_seconds,
+            "created_at": created_at,
+            "namespace": namespace,
+            "tier": tier,
+            "memory_type": memory_type,
+            "source_uri": source_uri,
+            "source_format": source_format,
+            "source_checksum": source_checksum,
+            "byte_offset": byte_offset,
+            "byte_length": byte_length,
+            "updated_at": updated_at,
+            "snapshot_id": snapshot_id,
+            "promotion_state": promotion_state,
+            "promotion_candidate": promotion_candidate,
+            "parent_memory": parent_memory,
+            "related_memories": related_memories,
+            "tags": tags,
+            "schema_version": schema_version,
+        }
         self._conn.execute(
-            """INSERT OR REPLACE INTO memories
-            (id, identifier, fact_text, embedding, embedding_dim, embedding_model,
-             source, importance, metadata_json, content_hash, ttl_seconds, created_at,
-             namespace, tier, memory_type, source_uri, source_format, source_checksum,
-             byte_offset, byte_length, updated_at, snapshot_id, promotion_state,
-             promotion_candidate, parent_memory, related_memories, tags, schema_version)
-            VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-            )""",
-            (
-                id,
-                identifier,
-                fact_text,
-                embedding,
-                embedding_dim,
-                embedding_model,
-                source,
-                importance,
-                metadata_json,
-                content_hash,
-                ttl_seconds,
-                created_at,
-                namespace,
-                tier,
-                memory_type,
-                source_uri,
-                source_format,
-                source_checksum,
-                byte_offset,
-                byte_length,
-                updated_at,
-                snapshot_id,
-                promotion_state,
-                promotion_candidate,
-                parent_memory,
-                related_memories,
-                tags,
-                schema_version,
-            ),
+            _INSERT_OR_REPLACE_SQL,
+            tuple(values[c] for c in _MEMORY_COLUMNS),
         )
         self._conn.commit()
         _trace.debug("insert", f"stored memory {id[:8]}…", detail={"identifier": identifier})
 
     def insert_many_ignore(self, records: Iterable[MemoryRecord]) -> int:
         """Insert many memory rows in one transaction, ignoring duplicate hashes/ids."""
-        rows = [
-            (
-                record.id,
-                record.identifier,
-                record.fact_text,
-                record.embedding,
-                record.embedding_dim,
-                record.embedding_model,
-                record.source,
-                record.importance,
-                record.metadata_json,
-                record.content_hash,
-                record.ttl_seconds,
-                record.created_at,
-                record.namespace,
-                record.tier,
-                record.memory_type,
-                record.source_uri,
-                record.source_format,
-                record.source_checksum,
-                record.byte_offset,
-                record.byte_length,
-                record.updated_at,
-                record.snapshot_id,
-                record.promotion_state,
-                record.promotion_candidate,
-                record.parent_memory,
-                record.related_memories,
-                record.tags,
-                record.schema_version,
-            )
-            for record in records
-        ]
+        rows = [tuple(getattr(record, c) for c in _MEMORY_COLUMNS) for record in records]
         if not rows:
             return 0
 
-        cursor = self._conn.executemany(
-            """INSERT OR IGNORE INTO memories
-            (id, identifier, fact_text, embedding, embedding_dim, embedding_model,
-             source, importance, metadata_json, content_hash, ttl_seconds, created_at,
-             namespace, tier, memory_type, source_uri, source_format, source_checksum,
-             byte_offset, byte_length, updated_at, snapshot_id, promotion_state,
-             promotion_candidate, parent_memory, related_memories, tags, schema_version)
-            VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                COALESCE(?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-            )""",
-            rows,
-        )
+        cursor = self._conn.executemany(_INSERT_OR_IGNORE_SQL, rows)
         self._conn.commit()
         inserted = cursor.rowcount if cursor.rowcount != -1 else 0
         _trace.debug("insert_many", f"stored {inserted} memories", detail={"attempted": len(rows)})
@@ -362,11 +403,10 @@ class MemoryDB:
     def search_with_cosine(self, query_embedding: bytes) -> list[dict[str, Any]]:
         """Return all memories with their cosine similarity to the query embedding."""
         rows = self._conn.execute(
-            """SELECT id, identifier, fact_text, importance, metadata_json, source,
+            f"""SELECT id, identifier, fact_text, importance, metadata_json, source,
                       created_at, cosine_sim(embedding, ?) AS cosine_score
                FROM memories
-               WHERE ttl_seconds IS NULL
-                  OR (strftime('%s', 'now') - strftime('%s', created_at)) < ttl_seconds
+               WHERE {_ttl_live()}
                ORDER BY cosine_score DESC""",
             (query_embedding,),
         ).fetchall()
@@ -379,15 +419,12 @@ class MemoryDB:
             return []
 
         rows = self._conn.execute(
-            """SELECT m.id, m.identifier, m.fact_text, m.importance, m.metadata_json,
+            f"""SELECT m.id, m.identifier, m.fact_text, m.importance, m.metadata_json,
                       m.source, m.created_at, bm25(memories_fts) AS bm25_score
                FROM memories_fts
                JOIN memories AS m ON m.rowid = memories_fts.rowid
                WHERE memories_fts MATCH ?
-                 AND (
-                    m.ttl_seconds IS NULL
-                    OR (strftime('%s', 'now') - strftime('%s', m.created_at)) < m.ttl_seconds
-                 )
+                 AND {_ttl_live("m.")}
                ORDER BY bm25_score ASC""",
             (fts_query,),
         ).fetchall()
@@ -446,8 +483,7 @@ class MemoryDB:
                        created_at
                 FROM memories
                 WHERE identifier = ?
-                  AND (ttl_seconds IS NULL
-                       OR (strftime('%s', 'now') - strftime('%s', created_at)) < ttl_seconds)
+                  AND {_ttl_live()}
                 ORDER BY created_at {direction}
                 LIMIT ?""",
             (identifier, limit),
@@ -458,93 +494,78 @@ class MemoryDB:
         """Merge memories from another HotMem SQLite database (fast-path).
 
         ATTACHs the source read-only, validates it has a memories table, and
-        inserts rows that don't already exist (dedupe on content_hash).
-        Embeddings are reused as-is — no recompute. Handles v0.1 and v2
-        source schemas (missing columns default).
+        inserts rows that don't already exist (dedupe on content_hash via the
+        unique index). Embeddings are reused as-is — no recompute and no Python
+        materialization: a single INSERT ... SELECT copies rows inside SQLite.
+        Handles v0.1 and v2 source schemas (missing columns default via
+        COALESCE). Column projection uses a fixed whitelist, never raw source
+        column names, so a crafted source DB cannot inject SQL.
 
         Returns (loaded, skipped_dupes).
         """
-        src = str(src_path)
+        resolved = Path(src_path).resolve()
+        # Read-only URI prevents a crafted source DB from writing to the main
+        # connection or mutating itself during the import. (immutable=1 is
+        # avoided because source DBs may use WAL and immutable skips the WAL.)
+        uri = f"file:{resolved}?mode=ro"
         alias = "_hotmem_src"
-        self._conn.execute(f"ATTACH DATABASE ? AS {alias}", (src,))
-        try:
-            tables = {
-                row["name"]
-                for row in self._conn.execute(
-                    f"SELECT name FROM {alias}.sqlite_master WHERE type='table'"
-                ).fetchall()
-            }
-            if "memories" not in tables:
-                raise ValueError(f"source database {src} has no 'memories' table; not a HotMem DB")
-
-            src_columns = {
-                row["name"]
-                for row in self._conn.execute(f"PRAGMA {alias}.table_info(memories)").fetchall()
-            }
-            required = {"id", "identifier", "fact_text", "embedding"}
-            missing = required - src_columns
-            if missing:
-                raise ValueError(
-                    f"source memories table missing required columns: {sorted(missing)}"
-                )
-
-            seen_hashes = self.content_hashes()
-            cols_sql = ", ".join(c for c in src_columns if c != "rowid")
-            rows = self._conn.execute(f"SELECT {cols_sql} FROM {alias}.memories").fetchall()
-
-            records: list[MemoryRecord] = []
-            skipped = 0
-            for row in rows:
-                d = dict(row)
-                ch = d.get("content_hash", "")
-                if ch and ch in seen_hashes:
-                    skipped += 1
-                    continue
-                if ch:
-                    seen_hashes.add(ch)
-                records.append(
-                    MemoryRecord(
-                        id=d["id"],
-                        identifier=d["identifier"],
-                        fact_text=d["fact_text"],
-                        embedding=d.get("embedding") or b"",
-                        embedding_dim=d.get("embedding_dim", EMBEDDING_DIM),
-                        embedding_model=d.get("embedding_model", ""),
-                        source=d.get("source", ""),
-                        importance=d.get("importance", 0.5),
-                        metadata_json=d.get("metadata_json", "{}"),
-                        content_hash=ch,
-                        ttl_seconds=d.get("ttl_seconds"),
-                        created_at=d.get("created_at"),
-                        namespace=d.get("namespace", ""),
-                        tier=d.get("tier", "hot"),
-                        memory_type=d.get("memory_type", "fact"),
-                        source_uri=d.get("source_uri", ""),
-                        source_format=d.get("source_format", ""),
-                        source_checksum=d.get("source_checksum", ""),
-                        byte_offset=d.get("byte_offset"),
-                        byte_length=d.get("byte_length"),
-                        updated_at=d.get("updated_at"),
-                        snapshot_id=d.get("snapshot_id", ""),
-                        promotion_state=d.get("promotion_state", "HOT"),
-                        promotion_candidate=d.get("promotion_candidate", 0),
-                        parent_memory=d.get("parent_memory", ""),
-                        related_memories=d.get("related_memories", "[]"),
-                        tags=d.get("tags", "[]"),
-                        schema_version=d.get("schema_version", 1),
+        with self._lock:
+            self._conn.execute(f"ATTACH DATABASE ? AS {alias}", (uri,))
+            try:
+                tables = {
+                    row["name"]
+                    for row in self._conn.execute(
+                        f"SELECT name FROM {alias}.sqlite_master WHERE type='table'"
+                    ).fetchall()
+                }
+                if "memories" not in tables:
+                    raise ValueError(
+                        f"source database {resolved} has no 'memories' table; not a HotMem DB"
                     )
+
+                src_columns = {
+                    row["name"]
+                    for row in self._conn.execute(f"PRAGMA {alias}.table_info(memories)").fetchall()
+                }
+                required = {"id", "identifier", "fact_text", "embedding"}
+                missing = required - src_columns
+                if missing:
+                    raise ValueError(
+                        f"source memories table missing required columns: {sorted(missing)}"
+                    )
+
+                # Project each canonical column from the source, defaulting
+                # missing optional columns. Only whitelisted column names are
+                # referenced — source column names are never interpolated.
+                # Unqualified names resolve to the single FROM table below.
+                projection = ", ".join(
+                    f"COALESCE({c}, {_COLUMN_DEFAULTS[c]})"
+                    if c in src_columns and c in _COLUMN_DEFAULTS
+                    else c
+                    if c in src_columns
+                    else _COLUMN_DEFAULTS.get(c, "NULL")
+                    for c in _MEMORY_COLUMNS
                 )
-            loaded = self.insert_many_ignore(records)
-            skipped += len(records) - loaded
-        finally:
-            with suppress(sqlite3.OperationalError):
-                self._conn.execute(f"DETACH DATABASE {alias}")
-            self._conn.commit()
+
+                count_row = self._conn.execute(f"SELECT COUNT(*) FROM {alias}.memories").fetchone()
+                attempted = count_row[0] if count_row else 0
+
+                cursor = self._conn.execute(
+                    f"INSERT OR IGNORE INTO memories ({', '.join(_MEMORY_COLUMNS)}) "
+                    f"SELECT {projection} FROM {alias}.memories"
+                )
+                self._conn.commit()
+                loaded = cursor.rowcount if cursor.rowcount != -1 else 0
+                skipped = attempted - loaded
+            finally:
+                with suppress(sqlite3.OperationalError):
+                    self._conn.execute(f"DETACH DATABASE {alias}")
+                self._conn.commit()
 
         _trace.info(
             "import_sqlite",
-            f"imported {loaded} memories from {src}",
-            detail={"loaded": loaded, "skipped_dupes": skipped, "src": src},
+            f"imported {loaded} memories from {resolved}",
+            detail={"loaded": loaded, "skipped_dupes": skipped, "src": str(resolved)},
         )
         return loaded, skipped
 

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -25,6 +25,7 @@ import re
 import sqlite3
 import struct
 from collections.abc import Iterable
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -452,6 +453,100 @@ class MemoryDB:
             (identifier, limit),
         ).fetchall()
         return [dict(r) for r in rows]
+
+    def import_sqlite(self, src_path: str | Path) -> tuple[int, int]:
+        """Merge memories from another HotMem SQLite database (fast-path).
+
+        ATTACHs the source read-only, validates it has a memories table, and
+        inserts rows that don't already exist (dedupe on content_hash).
+        Embeddings are reused as-is — no recompute. Handles v0.1 and v2
+        source schemas (missing columns default).
+
+        Returns (loaded, skipped_dupes).
+        """
+        src = str(src_path)
+        alias = "_hotmem_src"
+        self._conn.execute(f"ATTACH DATABASE ? AS {alias}", (src,))
+        try:
+            tables = {
+                row["name"]
+                for row in self._conn.execute(
+                    f"SELECT name FROM {alias}.sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            if "memories" not in tables:
+                raise ValueError(f"source database {src} has no 'memories' table; not a HotMem DB")
+
+            src_columns = {
+                row["name"]
+                for row in self._conn.execute(f"PRAGMA {alias}.table_info(memories)").fetchall()
+            }
+            required = {"id", "identifier", "fact_text", "embedding"}
+            missing = required - src_columns
+            if missing:
+                raise ValueError(
+                    f"source memories table missing required columns: {sorted(missing)}"
+                )
+
+            seen_hashes = self.content_hashes()
+            cols_sql = ", ".join(c for c in src_columns if c != "rowid")
+            rows = self._conn.execute(f"SELECT {cols_sql} FROM {alias}.memories").fetchall()
+
+            records: list[MemoryRecord] = []
+            skipped = 0
+            for row in rows:
+                d = dict(row)
+                ch = d.get("content_hash", "")
+                if ch and ch in seen_hashes:
+                    skipped += 1
+                    continue
+                if ch:
+                    seen_hashes.add(ch)
+                records.append(
+                    MemoryRecord(
+                        id=d["id"],
+                        identifier=d["identifier"],
+                        fact_text=d["fact_text"],
+                        embedding=d.get("embedding") or b"",
+                        embedding_dim=d.get("embedding_dim", EMBEDDING_DIM),
+                        embedding_model=d.get("embedding_model", ""),
+                        source=d.get("source", ""),
+                        importance=d.get("importance", 0.5),
+                        metadata_json=d.get("metadata_json", "{}"),
+                        content_hash=ch,
+                        ttl_seconds=d.get("ttl_seconds"),
+                        created_at=d.get("created_at"),
+                        namespace=d.get("namespace", ""),
+                        tier=d.get("tier", "hot"),
+                        memory_type=d.get("memory_type", "fact"),
+                        source_uri=d.get("source_uri", ""),
+                        source_format=d.get("source_format", ""),
+                        source_checksum=d.get("source_checksum", ""),
+                        byte_offset=d.get("byte_offset"),
+                        byte_length=d.get("byte_length"),
+                        updated_at=d.get("updated_at"),
+                        snapshot_id=d.get("snapshot_id", ""),
+                        promotion_state=d.get("promotion_state", "HOT"),
+                        promotion_candidate=d.get("promotion_candidate", 0),
+                        parent_memory=d.get("parent_memory", ""),
+                        related_memories=d.get("related_memories", "[]"),
+                        tags=d.get("tags", "[]"),
+                        schema_version=d.get("schema_version", 1),
+                    )
+                )
+            loaded = self.insert_many_ignore(records)
+            skipped += len(records) - loaded
+        finally:
+            with suppress(sqlite3.OperationalError):
+                self._conn.execute(f"DETACH DATABASE {alias}")
+            self._conn.commit()
+
+        _trace.info(
+            "import_sqlite",
+            f"imported {loaded} memories from {src}",
+            detail={"loaded": loaded, "skipped_dupes": skipped, "src": src},
+        )
+        return loaded, skipped
 
     def close(self) -> None:
         """Close the database connection."""

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -38,14 +38,36 @@ _trace = get_tracer("db")
 # statement generation and SQLite-to-SQLite import projection so the three
 # write paths cannot drift.
 _MEMORY_COLUMNS: tuple[str, ...] = (
-    "id", "identifier", "fact_text", "embedding", "embedding_dim",
-    "embedding_model", "source", "importance", "metadata_json",
-    "content_hash", "ttl_seconds", "created_at", "namespace", "tier",
-    "memory_type", "source_uri", "source_format", "source_checksum",
-    "byte_offset", "byte_length", "updated_at", "snapshot_id",
-    "promotion_state", "promotion_candidate", "parent_memory",
-    "related_memories", "tags", "schema_version",
+    "id",
+    "identifier",
+    "fact_text",
+    "embedding",
+    "embedding_dim",
+    "embedding_model",
+    "source",
+    "importance",
+    "metadata_json",
+    "content_hash",
+    "ttl_seconds",
+    "created_at",
+    "namespace",
+    "tier",
+    "memory_type",
+    "source_uri",
+    "source_format",
+    "source_checksum",
+    "byte_offset",
+    "byte_length",
+    "updated_at",
+    "snapshot_id",
+    "promotion_state",
+    "promotion_candidate",
+    "parent_memory",
+    "related_memories",
+    "tags",
+    "schema_version",
 )
+
 
 # TTL-live predicate — single source of truth so search and list agree on what
 # "expired" means. `alias` is "" for the unqualified table or "m." for joins.
@@ -469,8 +491,7 @@ class MemoryDB:
                 )
 
             src_columns = {
-                row["name"]
-                for row in src_conn.execute("PRAGMA table_info(memories)").fetchall()
+                row["name"] for row in src_conn.execute("PRAGMA table_info(memories)").fetchall()
             }
             required = {"id", "identifier", "fact_text", "embedding"}
             missing = required - src_columns

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -362,7 +362,7 @@ class MemoryDB:
         """Return all memories with their cosine similarity to the query embedding."""
         rows = self._conn.execute(
             """SELECT id, identifier, fact_text, importance, metadata_json, source,
-                      cosine_sim(embedding, ?) AS cosine_score
+                      created_at, cosine_sim(embedding, ?) AS cosine_score
                FROM memories
                WHERE ttl_seconds IS NULL
                   OR (strftime('%s', 'now') - strftime('%s', created_at)) < ttl_seconds
@@ -379,7 +379,7 @@ class MemoryDB:
 
         rows = self._conn.execute(
             """SELECT m.id, m.identifier, m.fact_text, m.importance, m.metadata_json,
-                      m.source, bm25(memories_fts) AS bm25_score
+                      m.source, m.created_at, bm25(memories_fts) AS bm25_score
                FROM memories_fts
                JOIN memories AS m ON m.rowid = memories_fts.rowid
                WHERE memories_fts MATCH ?
@@ -422,11 +422,36 @@ class MemoryDB:
         return {row["content_hash"] for row in rows}
 
     def exists(self, content_hash: str) -> bool:
-        """Check if a memory with this content hash already exists."""
+        """Check if a memory with this content_hash already exists."""
         row = self._conn.execute(
             "SELECT 1 FROM memories WHERE content_hash = ? LIMIT 1", (content_hash,)
         ).fetchone()
         return row is not None
+
+    def list_by_identifier(
+        self,
+        identifier: str,
+        *,
+        order: str = "asc",
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return memories for an identifier in created_at order (chronological).
+
+        Excludes TTL-expired memories, consistent with search.
+        """
+        direction = "ASC" if order.lower() == "asc" else "DESC"
+        rows = self._conn.execute(
+            f"""SELECT id, identifier, fact_text, importance, metadata_json, source,
+                       created_at
+                FROM memories
+                WHERE identifier = ?
+                  AND (ttl_seconds IS NULL
+                       OR (strftime('%s', 'now') - strftime('%s', created_at)) < ttl_seconds)
+                ORDER BY created_at {direction}
+                LIMIT ?""",
+            (identifier, limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
 
     def close(self) -> None:
         """Close the database connection."""

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -24,9 +24,7 @@ import math
 import re
 import sqlite3
 import struct
-import threading
 from collections.abc import Iterable
-from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -40,66 +38,14 @@ _trace = get_tracer("db")
 # statement generation and SQLite-to-SQLite import projection so the three
 # write paths cannot drift.
 _MEMORY_COLUMNS: tuple[str, ...] = (
-    "id",
-    "identifier",
-    "fact_text",
-    "embedding",
-    "embedding_dim",
-    "embedding_model",
-    "source",
-    "importance",
-    "metadata_json",
-    "content_hash",
-    "ttl_seconds",
-    "created_at",
-    "namespace",
-    "tier",
-    "memory_type",
-    "source_uri",
-    "source_format",
-    "source_checksum",
-    "byte_offset",
-    "byte_length",
-    "updated_at",
-    "snapshot_id",
-    "promotion_state",
-    "promotion_candidate",
-    "parent_memory",
-    "related_memories",
-    "tags",
-    "schema_version",
+    "id", "identifier", "fact_text", "embedding", "embedding_dim",
+    "embedding_model", "source", "importance", "metadata_json",
+    "content_hash", "ttl_seconds", "created_at", "namespace", "tier",
+    "memory_type", "source_uri", "source_format", "source_checksum",
+    "byte_offset", "byte_length", "updated_at", "snapshot_id",
+    "promotion_state", "promotion_candidate", "parent_memory",
+    "related_memories", "tags", "schema_version",
 )
-
-# SQL default expressions for optional columns, used when projecting rows from
-# a source DB that lacks them (v0.1 schema). Required columns (id, identifier,
-# fact_text, embedding) have no default and must exist in the source.
-_COLUMN_DEFAULTS: dict[str, str] = {
-    "embedding_dim": str(EMBEDDING_DIM),
-    "embedding_model": "''",
-    "source": "''",
-    "importance": "0.5",
-    "metadata_json": "'{}'",
-    "content_hash": "''",
-    "ttl_seconds": "NULL",
-    "created_at": "strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
-    "namespace": "''",
-    "tier": "'hot'",
-    "memory_type": "'fact'",
-    "source_uri": "''",
-    "source_format": "''",
-    "source_checksum": "''",
-    "byte_offset": "NULL",
-    "byte_length": "NULL",
-    "updated_at": "NULL",
-    "snapshot_id": "''",
-    "promotion_state": "'HOT'",
-    "promotion_candidate": "0",
-    "parent_memory": "''",
-    "related_memories": "'[]'",
-    "tags": "'[]'",
-    "schema_version": "1",
-}
-
 
 # TTL-live predicate — single source of truth so search and list agree on what
 # "expired" means. `alias` is "" for the unqualified table or "m." for joins.
@@ -254,7 +200,6 @@ class MemoryDB:
 
     def __init__(self, db_path: str | Path) -> None:
         self.db_path = str(db_path)
-        self._lock = threading.Lock()
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -493,74 +438,75 @@ class MemoryDB:
     def import_sqlite(self, src_path: str | Path) -> tuple[int, int]:
         """Merge memories from another HotMem SQLite database (fast-path).
 
-        ATTACHs the source read-only, validates it has a memories table, and
-        inserts rows that don't already exist (dedupe on content_hash via the
-        unique index). Embeddings are reused as-is — no recompute and no Python
-        materialization: a single INSERT ... SELECT copies rows inside SQLite.
-        Handles v0.1 and v2 source schemas (missing columns default via
-        COALESCE). Column projection uses a fixed whitelist, never raw source
-        column names, so a crafted source DB cannot inject SQL.
+        Opens the source on a SEPARATE connection and only ever SELECTs from it,
+        so a crafted source DB's triggers cannot affect the main database (a
+        different connection). Rows are streamed in batches and inserted via
+        insert_many_ignore, deduping on content_hash through the unique index.
+        Embeddings are reused as-is — no recompute. Handles v0.1 and v2 source
+        schemas (missing optional columns take dataclass defaults).
+
+        Using a separate connection (rather than ATTACH) avoids connection-global
+        schema state on the shared check_same_thread=False connection and works
+        with WAL-mode source databases across SQLite versions.
 
         Returns (loaded, skipped_dupes).
         """
         resolved = Path(src_path).resolve()
-        # Read-only URI prevents a crafted source DB from writing to the main
-        # connection or mutating itself during the import. (immutable=1 is
-        # avoided because source DBs may use WAL and immutable skips the WAL.)
-        uri = f"file:{resolved}?mode=ro"
-        alias = "_hotmem_src"
-        with self._lock:
-            self._conn.execute(f"ATTACH DATABASE ? AS {alias}", (uri,))
-            try:
-                tables = {
-                    row["name"]
-                    for row in self._conn.execute(
-                        f"SELECT name FROM {alias}.sqlite_master WHERE type='table'"
-                    ).fetchall()
-                }
-                if "memories" not in tables:
-                    raise ValueError(
-                        f"source database {resolved} has no 'memories' table; not a HotMem DB"
-                    )
-
-                src_columns = {
-                    row["name"]
-                    for row in self._conn.execute(f"PRAGMA {alias}.table_info(memories)").fetchall()
-                }
-                required = {"id", "identifier", "fact_text", "embedding"}
-                missing = required - src_columns
-                if missing:
-                    raise ValueError(
-                        f"source memories table missing required columns: {sorted(missing)}"
-                    )
-
-                # Project each canonical column from the source, defaulting
-                # missing optional columns. Only whitelisted column names are
-                # referenced — source column names are never interpolated.
-                # Unqualified names resolve to the single FROM table below.
-                projection = ", ".join(
-                    f"COALESCE({c}, {_COLUMN_DEFAULTS[c]})"
-                    if c in src_columns and c in _COLUMN_DEFAULTS
-                    else c
-                    if c in src_columns
-                    else _COLUMN_DEFAULTS.get(c, "NULL")
-                    for c in _MEMORY_COLUMNS
+        src_conn = sqlite3.connect(str(resolved))
+        src_conn.row_factory = sqlite3.Row
+        loaded = 0
+        skipped = 0
+        try:
+            tables = {
+                row["name"]
+                for row in src_conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            if "memories" not in tables:
+                raise ValueError(
+                    f"source database {resolved} has no 'memories' table; not a HotMem DB"
                 )
 
-                count_row = self._conn.execute(f"SELECT COUNT(*) FROM {alias}.memories").fetchone()
-                attempted = count_row[0] if count_row else 0
-
-                cursor = self._conn.execute(
-                    f"INSERT OR IGNORE INTO memories ({', '.join(_MEMORY_COLUMNS)}) "
-                    f"SELECT {projection} FROM {alias}.memories"
+            src_columns = {
+                row["name"]
+                for row in src_conn.execute("PRAGMA table_info(memories)").fetchall()
+            }
+            required = {"id", "identifier", "fact_text", "embedding"}
+            missing = required - src_columns
+            if missing:
+                raise ValueError(
+                    f"source memories table missing required columns: {sorted(missing)}"
                 )
-                self._conn.commit()
-                loaded = cursor.rowcount if cursor.rowcount != -1 else 0
-                skipped = attempted - loaded
-            finally:
-                with suppress(sqlite3.OperationalError):
-                    self._conn.execute(f"DETACH DATABASE {alias}")
-                self._conn.commit()
+
+            # SELECT only whitelisted canonical columns that exist in the source.
+            # Source-provided column names are never interpolated into SQL, so a
+            # crafted column name cannot inject.
+            select_cols = [c for c in _MEMORY_COLUMNS if c in src_columns]
+            col_sql = ", ".join(select_cols)
+            cursor = src_conn.execute(f"SELECT {col_sql} FROM memories")
+
+            seen_hashes = self.content_hashes()
+            while True:
+                batch = cursor.fetchmany(1000)
+                if not batch:
+                    break
+                records: list[MemoryRecord] = []
+                for row in batch:
+                    d = dict(row)
+                    ch = d.get("content_hash", "")
+                    if ch and ch in seen_hashes:
+                        skipped += 1
+                        continue
+                    if ch:
+                        seen_hashes.add(ch)
+                    # Build from the columns present; dataclass defaults fill the
+                    # rest (missing v2 columns in v0.1 sources).
+                    records.append(MemoryRecord(**{c: d[c] for c in select_cols}))
+                if records:
+                    loaded += self.insert_many_ignore(records)
+        finally:
+            src_conn.close()
 
         _trace.info(
             "import_sqlite",

--- a/src/hotmem/openapi.py
+++ b/src/hotmem/openapi.py
@@ -1,0 +1,48 @@
+"""HotMem OpenAPI spec export.
+
+Purpose:
+    Generate and export the FastAPI OpenAPI spec as static JSON/YAML so it can
+    be versioned and published with the docs site, independent of a running
+    server.
+
+Interface:
+    export_openapi() -> dict[str, Any]
+    dump_openapi(path, fmt="json"|"yaml") -> Path
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hotmem.server import create_app
+
+
+def export_openapi() -> dict[str, Any]:
+    """Return the OpenAPI schema for the HotMem FastAPI app."""
+    app = create_app(db_path=":memory:")
+    return app.openapi()
+
+
+def dump_openapi(path: str | Path, *, fmt: str = "json") -> Path:
+    """Write the OpenAPI spec to a file. fmt is 'json' or 'yaml'.
+
+    YAML support requires PyYAML; if absent, falls back to JSON with a warning
+    and appends .json to the path.
+    """
+    path = Path(path)
+    spec = export_openapi()
+
+    if fmt == "yaml":
+        try:
+            import yaml
+        except ImportError as err:
+            raise ImportError(
+                "YAML export requires PyYAML. Install with: uv pip install pyyaml"
+            ) from err
+        path.write_text(yaml.dump(spec, sort_keys=False, default_flow_style=False))
+    else:
+        path.write_text(json.dumps(spec, indent=2) + "\n")
+
+    return path

--- a/src/hotmem/playground.py
+++ b/src/hotmem/playground.py
@@ -1,0 +1,194 @@
+"""HotMem playground — interactive terminal UI for add/search/inspect.
+
+Purpose:
+    Make demos and debugging instant without curl or a Python script.
+    Works against a running server (HTTP) or directly against a DB file.
+
+Interface:
+    run_playground(mode, db_path, url) -> None
+
+Deps: rich (optional, [playground] extra), hotmem.client or hotmem.db
+
+Extension: richer panels, pagination, or a full textual app live here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _import_rich():
+    try:
+        from rich.console import Console
+        from rich.panel import Panel
+        from rich.table import Table
+
+        return Console(), Panel, Table
+    except ImportError as err:
+        raise ImportError(
+            "Playground requires rich. Install with: uv pip install 'hotmem[playground]'"
+        ) from err
+
+
+class _DirectBackend:
+    """Backend that operates directly against a SQLite DB file."""
+
+    def __init__(self, db_path: str) -> None:
+        from hotmem.db import MemoryDB
+
+        self._db = MemoryDB(db_path)
+        self.db_path = db_path
+
+    def add(self, identifier: str, fact: str, **kwargs: Any) -> dict[str, Any]:
+        import uuid
+
+        from hotmem.embed import EMBEDDING_DIM, EMBEDDING_MODEL, embed_text, pack_embedding
+        from hotmem.swap import compute_content_hash
+
+        memory_id = uuid.uuid4().hex
+        content_hash = compute_content_hash(identifier, fact)
+        vec = embed_text(fact)
+        blob = pack_embedding(vec)
+        self._db.insert(
+            id=memory_id,
+            identifier=identifier,
+            fact_text=fact,
+            embedding=blob,
+            embedding_dim=EMBEDDING_DIM,
+            embedding_model=EMBEDDING_MODEL,
+            source=kwargs.get("source", ""),
+            importance=kwargs.get("importance", 0.5),
+            content_hash=content_hash,
+        )
+        return {"memory_id": memory_id, "content_hash": content_hash, "trace_ms": 0.0}
+
+    def search(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        from hotmem.search import search_memories
+
+        return search_memories(self._db, query=query, top_k=top_k)
+
+    def count(self) -> int:
+        return self._db.count()
+
+    def close(self) -> None:
+        self._db.close()
+
+
+class _HttpBackend:
+    """Backend that proxies to a running HotMem server."""
+
+    def __init__(self, url: str) -> None:
+        from hotmem.client import HotMemClient
+
+        self._client = HotMemClient(url)
+        self.url = url
+
+    def add(self, identifier: str, fact: str, **kwargs: Any) -> dict[str, Any]:
+        return self._client.add(
+            identifier=identifier,
+            fact=fact,
+            source=kwargs.get("source", ""),
+            importance=kwargs.get("importance", 0.5),
+        )
+
+    def search(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        return self._client.search(query=query, top_k=top_k)
+
+    def count(self) -> int:
+        return self._client.health()["memory_count"]
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def run_playground(*, db_path: str | None = None, url: str | None = None) -> None:
+    """Run the interactive playground loop.
+
+    Exactly one of db_path or url must be provided.
+    """
+    if db_path and url:
+        raise ValueError("specify either db_path or url, not both")
+    if not db_path and not url:
+        raise ValueError("specify either --db or --url")
+
+    console, Panel, Table = _import_rich()
+
+    if url:
+        backend: _DirectBackend | _HttpBackend = _HttpBackend(url)
+        where = f"server @ {url}"
+    else:
+        backend = _DirectBackend(db_path)  # type: ignore[arg-type]
+        where = f"db @ {db_path}"
+
+    console.print(
+        Panel.fit(
+            f"[bold]HotMem Playground[/bold]\n[dim]connected to {where}[/dim]\n"
+            "[dim]commands: add | search | count | help | quit[/dim]",
+            border_style="blue",
+        )
+    )
+
+    try:
+        while True:
+            try:
+                line = console.input("[bold green]hotmem>[/bold green] ").strip()
+            except (EOFError, KeyboardInterrupt):
+                break
+            if not line:
+                continue
+
+            parts = line.split(maxsplit=1)
+            cmd = parts[0].lower()
+            rest = parts[1] if len(parts) > 1 else ""
+
+            if cmd in ("quit", "exit", "q"):
+                break
+            elif cmd == "help":
+                console.print(
+                    Panel.fit(
+                        "[bold]add[/bold] <identifier> | <fact>   add a memory\n"
+                        "[bold]search[/bold] <query>            search memories\n"
+                        "[bold]count[/bold]                     show memory count\n"
+                        "[bold]quit[/bold]                      exit",
+                        title="Commands",
+                        border_style="dim",
+                    )
+                )
+            elif cmd == "count":
+                console.print(f"[cyan]{backend.count()}[/cyan] memories")
+            elif cmd == "add":
+                if "|" not in rest:
+                    console.print("[red]Usage: add <identifier> | <fact>[/red]")
+                    continue
+                identifier, fact = rest.split("|", 1)
+                result = backend.add(identifier.strip(), fact.strip())
+                table = Table(show_header=False, box=None)
+                table.add_row("memory_id", result["memory_id"])
+                table.add_row("content_hash", result.get("content_hash", ""))
+                console.print(Panel(table, title="Added", border_style="green"))
+            elif cmd == "search":
+                if not rest:
+                    console.print("[red]Usage: search <query>[/red]")
+                    continue
+                results = backend.search(rest)
+                if not results:
+                    console.print("[dim]No matches.[/dim]")
+                    continue
+                table = Table(title=f"Search: {rest}")
+                table.add_column("#", style="dim", width=3)
+                table.add_column("Score", justify="right", style="cyan")
+                table.add_column("Identifier", style="yellow")
+                table.add_column("Content")
+                for i, m in enumerate(results, 1):
+                    table.add_row(
+                        str(i),
+                        str(m.get("score", "")),
+                        m.get("identifier", ""),
+                        m.get("content", "")[:80],
+                    )
+                console.print(table)
+            else:
+                console.print(f"[red]Unknown command: {cmd}[/red]  [dim]type 'help'[/dim]")
+    finally:
+        backend.close()
+        console.print("[dim]bye.[/dim]")

--- a/src/hotmem/search.py
+++ b/src/hotmem/search.py
@@ -94,6 +94,7 @@ def search_memories(
                     "memory_id": item["id"],
                     "identifier": item["identifier"],
                     "score": round(item["final_score"], 4),
+                    "created_at": item.get("created_at"),
                 }
             )
 

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -19,6 +19,7 @@ import json
 import time
 import uuid
 from contextlib import asynccontextmanager
+from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,8 @@ from hotmem.swap import snapshot as swap_snapshot
 from hotmem.trace import Timer, get_tracer, new_trace_id
 
 _trace = get_tracer("server")
+
+_VERSION = pkg_version("hotmem")
 
 # ── App state (set during lifespan) ──────────────────────────────────────────
 
@@ -113,7 +116,7 @@ def create_app(
     app = FastAPI(
         title="HotMem",
         description="Local-first memory sidecar for agent applications",
-        version="0.1.0",
+        version=_VERSION,
         lifespan=lifespan,
     )
 

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -189,6 +189,26 @@ def create_app(
             "trace_ms": round(t.ms, 2),
         }
 
+    @app.get("/v1/memories")
+    async def list_memories(
+        identifier: str,
+        order: str = "asc",
+        limit: int = 100,
+    ):
+        """Return memories for an identifier in created_at order."""
+        db: MemoryDB = _state["db"]
+        if order not in ("asc", "desc"):
+            raise HTTPException(status_code=400, detail="order must be 'asc' or 'desc'")
+        if limit < 1 or limit > 1000:
+            raise HTTPException(status_code=400, detail="limit must be 1..1000")
+        with Timer() as t:
+            rows = db.list_by_identifier(identifier, order=order, limit=limit)
+        return {
+            "memories": rows,
+            "count": len(rows),
+            "trace_ms": round(t.ms, 2),
+        }
+
     @app.post("/v1/hydrate")
     async def hydrate(req: HydrateRequest):
         db: MemoryDB = _state["db"]

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -19,6 +19,7 @@ import json
 import time
 import uuid
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import Any
@@ -36,7 +37,13 @@ from hotmem.trace import Timer, get_tracer, new_trace_id
 
 _trace = get_tracer("server")
 
-_VERSION = pkg_version("hotmem")
+try:
+    _VERSION = pkg_version("hotmem")
+except PackageNotFoundError:
+    try:
+        from hotmem import __version__ as _VERSION
+    except ImportError:
+        _VERSION = "0.0.0+unknown"
 
 # ── App state (set during lifespan) ──────────────────────────────────────────
 

--- a/src/hotmem/swap.py
+++ b/src/hotmem/swap.py
@@ -115,14 +115,20 @@ def _stored_embedding(record: dict) -> bytes | None:
 
 
 def hydrate(db: MemoryDB, swap_path: str | Path) -> HydrateResult:
-    """Load memories from a JSONL or JSONL.GZ swap file into the database.
+    """Load memories from a swap file into the database.
 
+    Accepts JSONL, JSONL.GZ, or a HotMem SQLite database (.sqlite/.db).
     Deduplicates by content_hash - skips rows that already exist in the DB.
+    For SQLite sources, embeddings are reused as-is (fast-path, no recompute).
     """
     swap_path = Path(swap_path)
     if not swap_path.exists():
         _trace.warn("hydrate", "swap file not found", detail={"path": str(swap_path)})
         return HydrateResult(loaded=0, skipped_dupes=0)
+
+    if swap_path.suffix.lower() in (".sqlite", ".db"):
+        loaded, skipped = db.import_sqlite(swap_path)
+        return HydrateResult(loaded=loaded, skipped_dupes=skipped)
 
     with Timer() as t:
         records: list[MemoryRecord] = []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -130,3 +130,53 @@ def test_hydrate_endpoint_rejects_unsupported_swap_extension(
 
     assert resp.status_code == 400
     assert "supported: .jsonl, .jsonl.gz" in resp.json()["detail"]
+
+
+def test_search_includes_created_at(client: TestClient):
+    client.post(
+        "/v1/add",
+        json={"identifier": "user", "fact": "prefers dark mode"},
+    )
+    resp = client.post("/v1/search", json={"query": "theme", "top_k": 5})
+    assert resp.status_code == 200
+    memories = resp.json()["memories"]
+    assert len(memories) == 1
+    assert "created_at" in memories[0]
+    assert memories[0]["created_at"] is not None
+
+
+def test_list_memories_endpoint(client: TestClient):
+    for i in range(3):
+        client.post(
+            "/v1/add",
+            json={"identifier": "chat", "fact": f"message {i}"},
+        )
+
+    resp = client.get("/v1/memories", params={"identifier": "chat", "order": "asc"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 3
+    assert all("created_at" in m for m in data["memories"])
+
+
+def test_list_memories_filters_by_identifier(client: TestClient):
+    client.post("/v1/add", json={"identifier": "a", "fact": "aaa"})
+    client.post("/v1/add", json={"identifier": "b", "fact": "bbb"})
+
+    resp = client.get("/v1/memories", params={"identifier": "a"})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+
+def test_list_memories_limit(client: TestClient):
+    for i in range(5):
+        client.post("/v1/add", json={"identifier": "chat", "fact": f"m{i}"})
+
+    resp = client.get("/v1/memories", params={"identifier": "chat", "limit": 2})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 2
+
+
+def test_list_memories_rejects_bad_order(client: TestClient):
+    resp = client.get("/v1/memories", params={"identifier": "x", "order": "sideways"})
+    assert resp.status_code == 400

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -285,3 +285,71 @@ def test_v2_fields_default_when_unset(tmp_db: MemoryDB):
     assert row["schema_version"] == 1
     assert row["byte_offset"] is None
     assert row["byte_length"] is None
+
+
+def test_list_by_identifier_chronological(tmp_db: MemoryDB):
+    blob = pack_embedding(embed_text("fact"))
+    tmp_db.insert(
+        id="first",
+        identifier="chat",
+        fact_text="hello",
+        embedding=blob,
+        created_at="2026-01-01T00:00:00Z",
+    )
+    tmp_db.insert(
+        id="second",
+        identifier="chat",
+        fact_text="world",
+        embedding=blob,
+        created_at="2026-06-01T00:00:00Z",
+    )
+    tmp_db.insert(
+        id="other",
+        identifier="other",
+        fact_text="noise",
+        embedding=blob,
+        created_at="2026-03-01T00:00:00Z",
+    )
+
+    asc = tmp_db.list_by_identifier("chat", order="asc")
+    assert [r["id"] for r in asc] == ["first", "second"]
+    assert all("created_at" in r for r in asc)
+
+    desc = tmp_db.list_by_identifier("chat", order="desc")
+    assert [r["id"] for r in desc] == ["second", "first"]
+
+
+def test_list_by_identifier_limit(tmp_db: MemoryDB):
+    blob = pack_embedding(embed_text("fact"))
+    for i in range(5):
+        tmp_db.insert(
+            id=f"m{i}",
+            identifier="chat",
+            fact_text=f"msg {i}",
+            embedding=blob,
+            created_at=f"2026-01-0{i + 1}T00:00:00Z",
+        )
+    rows = tmp_db.list_by_identifier("chat", order="asc", limit=2)
+    assert len(rows) == 2
+    assert [r["id"] for r in rows] == ["m0", "m1"]
+
+
+def test_list_by_identifier_excludes_expired(tmp_db: MemoryDB):
+    blob = pack_embedding(embed_text("fact"))
+    tmp_db.insert(
+        id="live",
+        identifier="chat",
+        fact_text="alive",
+        embedding=blob,
+        created_at="2026-01-01T00:00:00Z",
+    )
+    tmp_db.insert(
+        id="dead",
+        identifier="chat",
+        fact_text="expired",
+        embedding=blob,
+        ttl_seconds=1,
+        created_at="2000-01-01T00:00:00Z",
+    )
+    rows = tmp_db.list_by_identifier("chat", order="asc")
+    assert [r["id"] for r in rows] == ["live"]

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -1,0 +1,56 @@
+"""Tests for hotmem.playground — interactive TUI backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hotmem.playground import _DirectBackend
+
+
+def _fresh_db(tmp_path: Path) -> str:
+    return str(tmp_path / "playground.sqlite")
+
+
+def test_direct_backend_add_and_search(tmp_path):
+    backend = _DirectBackend(_fresh_db(tmp_path))
+    try:
+        result = backend.add("user", "prefers dark mode")
+        assert "memory_id" in result
+        assert "content_hash" in result
+        assert backend.count() == 1
+
+        results = backend.search("theme preference")
+        assert len(results) >= 1
+        assert results[0]["identifier"] == "user"
+        assert "score" in results[0]
+    finally:
+        backend.close()
+
+
+def test_direct_backend_multiple_memories(tmp_path):
+    backend = _DirectBackend(_fresh_db(tmp_path))
+    try:
+        backend.add("project", "uses FastAPI and SQLite")
+        backend.add("project", "deployed with Docker")
+        assert backend.count() == 2
+
+        results = backend.search("deployment")
+        assert len(results) >= 1
+    finally:
+        backend.close()
+
+
+def test_run_playground_requires_db_or_url():
+    from hotmem.playground import run_playground
+
+    with pytest.raises(ValueError, match="specify either"):
+        run_playground()
+
+
+def test_run_playground_rejects_both_db_and_url(tmp_path):
+    from hotmem.playground import run_playground
+
+    with pytest.raises(ValueError, match="not both"):
+        run_playground(db_path=_fresh_db(tmp_path), url="http://localhost:8711")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,3 +77,10 @@ def test_search_filters_expired_memories(tmp_db: MemoryDB):
     results = search_memories(tmp_db, "invoice memory", top_k=5)
 
     assert [r["memory_id"] for r in results] == ["permanent"]
+
+
+def test_search_includes_created_at(tmp_db: MemoryDB):
+    _add_fact(tmp_db, "1", "invoice validation required")
+    results = search_memories(tmp_db, "invoice", top_k=5)
+    assert "created_at" in results[0]
+    assert results[0]["created_at"] is not None

--- a/tests/test_swap.py
+++ b/tests/test_swap.py
@@ -231,3 +231,97 @@ def test_hydrate_recomputes_incompatible_stored_embedding(
 
     assert result.loaded == 1
     assert tmp_db.all_rows(include_embedding=True)[0]["embedding"] == recomputed_blob
+
+
+def test_hydrate_sqlite_fast_path(tmp_path):
+    """SQLite-to-SQLite import reuses embeddings and dedupes on content_hash."""
+    src_path = tmp_path / "src.sqlite"
+    dst_path = tmp_path / "dst.sqlite"
+
+    src = MemoryDB(src_path)
+    blob = pack_embedding(embed_text("fast path fact"))
+    src.insert(
+        id="s1",
+        identifier="x",
+        fact_text="fast path fact",
+        embedding=blob,
+        content_hash="hash-s1",
+    )
+    src.close()
+
+    dst = MemoryDB(dst_path)
+    result = hydrate(dst, src_path)
+    assert result.loaded == 1
+    assert result.skipped_dupes == 0
+    assert dst.count() == 1
+
+    row = dst.all_rows(include_embedding=True)[0]
+    assert row["embedding"] == blob
+    dst.close()
+
+
+def test_hydrate_sqlite_skips_existing_hashes(tmp_path):
+    src_path = tmp_path / "src.sqlite"
+    dst_path = tmp_path / "dst.sqlite"
+
+    blob = pack_embedding(embed_text("dup fact"))
+
+    src = MemoryDB(src_path)
+    src.insert(id="s1", identifier="x", fact_text="dup fact", embedding=blob, content_hash="dup")
+    src.close()
+
+    dst = MemoryDB(dst_path)
+    dst.insert(
+        id="existing", identifier="x", fact_text="dup fact", embedding=blob, content_hash="dup"
+    )
+
+    result = hydrate(dst, src_path)
+    assert result.loaded == 0
+    assert result.skipped_dupes == 1
+    assert dst.count() == 1
+    dst.close()
+
+
+def test_hydrate_sqlite_rejects_non_hotmem_db(tmp_path):
+    import sqlite3
+
+    bad_path = tmp_path / "bad.sqlite"
+    conn = sqlite3.connect(bad_path)
+    conn.execute("CREATE TABLE foo (x INTEGER)")
+    conn.commit()
+    conn.close()
+
+    dst = MemoryDB(tmp_path / "dst.sqlite")
+    with pytest.raises(ValueError, match="no 'memories' table"):
+        hydrate(dst, bad_path)
+    dst.close()
+
+
+def test_hydrate_sqlite_imports_v01_source(tmp_path):
+    """A v0.1 schema source DB (no v2 columns) imports with defaults."""
+    import sqlite3
+
+    v01_path = tmp_path / "v01.sqlite"
+    conn = sqlite3.connect(v01_path)
+    conn.execute(
+        """CREATE TABLE memories (
+            id TEXT PRIMARY KEY, identifier TEXT, fact_text TEXT,
+            embedding BLOB, content_hash TEXT DEFAULT ''
+        )"""
+    )
+    blob = pack_embedding(embed_text("legacy sqlite fact"))
+    conn.execute(
+        "INSERT INTO memories (id, identifier, fact_text, embedding, content_hash)"
+        " VALUES (?,?,?,?,?)",
+        ("old1", "x", "legacy sqlite fact", blob, "h-old1"),
+    )
+    conn.commit()
+    conn.close()
+
+    dst = MemoryDB(tmp_path / "dst.sqlite")
+    result = hydrate(dst, v01_path)
+    assert result.loaded == 1
+    row = dst.all_rows()[0]
+    assert row["promotion_state"] == "HOT"
+    assert row["schema_version"] == 1
+    dst.close()

--- a/tests/test_swap.py
+++ b/tests/test_swap.py
@@ -325,3 +325,37 @@ def test_hydrate_sqlite_imports_v01_source(tmp_path):
     assert row["promotion_state"] == "HOT"
     assert row["schema_version"] == 1
     dst.close()
+
+
+def test_hydrate_sqlite_rejects_malicious_column_name(tmp_path):
+    """A crafted source DB with a SQL-injection column name must not execute."""
+    import sqlite3
+
+    evil_path = tmp_path / "evil.sqlite"
+    conn = sqlite3.connect(evil_path)
+    # Column name that would break out of a SELECT if interpolated raw.
+    evil_col = "x) UNION SELECT sql FROM sqlite_master--"
+    create_sql = (
+        'CREATE TABLE memories ("id" TEXT, "identifier" TEXT, '
+        '"fact_text" TEXT, "embedding" BLOB, '
+        f'"{evil_col}" TEXT)'
+    )
+    conn.execute(create_sql)
+    conn.execute(
+        "INSERT INTO memories (id, identifier, fact_text, embedding)"
+        " VALUES ('e1', 'x', 'evil', X'00')"
+    )
+    conn.commit()
+    conn.close()
+
+    dst = MemoryDB(tmp_path / "dst.sqlite")
+    # import_sqlite projects only whitelisted columns, so the malicious column
+    # is never referenced. The row imports cleanly via the known columns.
+    result = hydrate(dst, evil_path)
+    assert result.loaded == 1
+    assert dst.count() == 1
+    # The injected column must not have leaked sqlite_master contents anywhere.
+    row = dst.all_rows()[0]
+    assert row["id"] == "e1"
+    assert row["fact_text"] == "evil"
+    dst.close()

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,28 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -119,6 +141,95 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -319,6 +430,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -344,8 +467,16 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "pyyaml" },
+]
 mcp = [
     { name = "mcp" },
+]
+playground = [
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -354,12 +485,16 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0,<2" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6,<2" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5,<10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9,<10" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6,<7" },
+    { name = "pyyaml", marker = "extra == 'docs'", specifier = ">=6.0,<7" },
+    { name = "rich", marker = "extra == 'playground'", specifier = ">=13.7,<14" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15,<1" },
     { name = "uvicorn", specifier = ">=0.30,<1" },
 ]
-provides-extras = ["mcp", "dev"]
+provides-extras = ["mcp", "playground", "docs", "dev"]
 
 [[package]]
 name = "httpcore"
@@ -417,6 +552,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -441,6 +588,101 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -469,12 +711,126 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -650,6 +1006,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -677,6 +1046,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -720,6 +1101,73 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -731,6 +1179,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
 ]
 
 [[package]]
@@ -896,6 +1372,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -997,6 +1482,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1007,4 +1501,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
## Summary

Phase 3 DX work plus two retrieval/import tickets — five independent tickets, each its own commit. Built on top of `vnext/m0-m1` (now merged to main).

| Commit | Issue | Scope |
|---|---|---|
| `8263d47` | #14 | OpenAPI spec export (`hotmem openapi`) + MkDocs Material docs site + GitHub Pages workflow |
| `adcfb0d` | #12 | Multi-stage Dockerfile (alpine, non-root, /data volume) + multi-arch GH Actions publish workflow (GHCR + Docker Hub) |
| `a7b408e` | #13 | `hotmem playground` interactive TUI — add/search/inspect against a DB file or running server |
| `fda283b` | #34 | Surface `created_at` in search output + `GET /v1/memories` chronological retrieval + client `.list()` |
| `d0abadd` | #26 | SQLite fast-path memory import (hydrate `.sqlite`/`.db`) — embedding reuse, dedupe, v0.1 source compat |
| `30311b4` | review | Address all review findings: import_sqlite security (read-only, no column injection), streaming, TTL dedup, shared column defs, version fallback, composite index |
| `7e0e59e` + `4cbf0bd` | fix | Replace ATTACH(mode=ro) with separate read-only connection (CI fix for SQLite 3.12+ WAL); ruff format alignment |

## What changed

- **src/hotmem/openapi.py** — OpenAPI JSON/YAML export module.
- **src/hotmem/playground.py** — rich-based TUI with `_DirectBackend` (SQLite) and `_HttpBackend` (server).
- **src/hotmem/cli.py** — `openapi` + `playground` subcommands.
- **src/hotmem/server.py** — `GET /v1/memories` endpoint; version synced to installed package (with fallback).
- **src/hotmem/db.py** — `list_by_identifier`, `import_sqlite` (separate read-only connection, batched streaming), shared `_MEMORY_COLUMNS`/`_ttl_live` helpers, composite index.
- **src/hotmem/client.py** — `.list()` sync + async.
- **src/hotmem/search.py** — `created_at` in message objects.
- **src/hotmem/swap.py** — `hydrate` dispatches `.sqlite`/`.db` to fast path.
- **Dockerfile** + **.dockerignore** — multi-stage alpine, non-root user, port 8711.
- **.github/workflows/** — `docs.yml` (MkDocs + Pages), `docker.yml` (multi-arch build/push).
- **mkdocs.yml** + **docs/** — quickstart, API reference, CLI docs.
- **pyproject.toml** — `[docs]` and `[playground]` optional dependency groups.

## Verification

- [x] `ruff check` clean, `ruff format --check` clean
- [x] Full suite: **101 tests pass**
- [x] All CI checks green (Python 3.11/3.12/3.13/3.14, adapters, TypeScript)
- [x] `hotmem openapi --output openapi.json` produces valid spec (5 paths, version synced)
- [x] Docker image build verified locally — **84.6MB** (under 100MB target), add/search/persistence round-trip passes, volume persists across restart
- [x] `import_sqlite` security regression test (malicious column name) passes
- [x] Review findings addressed (security, perf, concurrency, dedup)

## Compatibility

- All additions are additive; core behavior unchanged for existing callers.
- New deps are optional (`[docs]`, `[playground]`); core install stays dependency-free.
- `import_sqlite` opens the source on a separate read-only connection (no ATTACH, no lock needed).
- Legacy `swap.jsonl` hydration unchanged; `.sqlite`/`.db` dispatch is additive.

## Security review

`import_sqlite` was hardened after code review:
- Source opened on a **separate connection** that only SELECTs — source triggers cannot reach the main DB.
- Column projection uses a fixed whitelist (`_MEMORY_COLUMNS`); source column names are never interpolated into SQL (injection-proof). Regression test added.

Closes #12, Closes #13, Closes #14
Closes #26, Closes #34
