### PR TITLE
Phase 4 adoption: #15 mem0 import, #16 rich CLI, #17 examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: astral-sh/setup-uv@v4
       - run: uv venv
       - run: uv pip install -e ".[dev,mcp]"
-      - run: uv run ruff check src/ tests/
-      - run: uv run ruff format --check src/ tests/
+      - run: uv run ruff check src/ tests/ examples/
+      - run: uv run ruff format --check src/ tests/ examples/
       - run: uv run pytest --cov=hotmem --cov-report=xml
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ swap.jsonl
 .DS_Store
 .pytest_cache/
 .ruff_cache/
+.coverage
+coverage.xml
 dev_roadmap.md
 planned-evolution.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,16 +16,16 @@ Copy-paste-runnable examples showing HotMem with each framework and runtime.
 
 ## Prerequisites
 
-Most Python examples target a running sidecar:
+The common setup for most examples (sidecar-based ones):
 
 ```sh
-pip install -e ".[dev,mcp]"          # HotMem itself
-pip install -e adapters/<name>        # the adapter for the example
+pip install -e ".[dev,mcp]"          # HotMem itself + dev/test deps
 hotmem serve                          # http://127.0.0.1:8711
 ```
 
-Framework-specific deps (e.g. `langchain`, `crewai`, `openai`) are listed in
-each example's README — they are NOT bundled with HotMem.
+Per-example READMEs link here and only list their example-specific framework
+deps (adapter package + framework). The FastAPI and MCP examples use different
+extras (`[dev]` / `[mcp]`) — noted in their own READMEs.
 
 ## Notes
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# HotMem Examples
+
+Copy-paste-runnable examples showing HotMem with each framework and runtime.
+
+## Index
+
+| Example | What it shows | Language | Run |
+| --- | --- | --- | --- |
+| [langchain_agent](langchain_agent) | HotMem retriever + LLM agent loop | Python | `python agent.py` |
+| [crewai_crew](crewai_crew) | Shared HotMem memory across a CrewAI crew | Python | `python crew.py` |
+| [autogen_group_chat](autogen_group_chat) | Group chat with HotMem memory plugin | Python | `python chat.py` |
+| [pydanticai_agent](pydanticai_agent) | Typed Pydantic AI agent with HotMem deps | Python | `python agent.py` |
+| [fastapi_backend](fastapi_backend) | Standalone FastAPI app using HotMem as a library | Python | `uvicorn app:app` |
+| [mcp_claude_desktop](mcp_claude_desktop) | `hotmem mcp` wired into Claude Desktop | Config | paste config + restart |
+| [typescript](typescript) | TS client add/search against `hotmem serve` | TypeScript | `npx tsx agent.ts` |
+
+## Prerequisites
+
+Most Python examples target a running sidecar:
+
+```sh
+pip install -e ".[dev,mcp]"          # HotMem itself
+pip install -e adapters/<name>        # the adapter for the example
+hotmem serve                          # http://127.0.0.1:8711
+```
+
+Framework-specific deps (e.g. `langchain`, `crewai`, `openai`) are listed in
+each example's README — they are NOT bundled with HotMem.
+
+## Notes
+
+- Examples are illustrative and not exercised by the test suite (they pull
+  heavy, optional framework deps and may need API keys). They are linted by
+  `ruff check examples/` in CI to catch syntax/import-order errors.
+- The [fastapi_backend](fastapi_backend) example uses HotMem **as a library**
+  (in-process `MemoryDB`) — no sidecar required.

--- a/examples/autogen_group_chat/README.md
+++ b/examples/autogen_group_chat/README.md
@@ -1,0 +1,20 @@
+# autogen_group_chat
+
+A 3-agent AutoGen group chat using the HotMem memory plugin so each agent
+recalls prior turns before speaking.
+
+## Setup
+
+```sh
+pip install -e ".[dev,mcp]"
+pip install -e adapters/autogen
+pip install "autogen-agentchat>=0.4"              # framework dep
+
+hotmem serve
+```
+
+## Run
+
+```sh
+python chat.py
+```

--- a/examples/autogen_group_chat/README.md
+++ b/examples/autogen_group_chat/README.md
@@ -5,12 +5,12 @@ recalls prior turns before speaking.
 
 ## Setup
 
-```sh
-pip install -e ".[dev,mcp]"
-pip install -e adapters/autogen
-pip install "autogen-agentchat>=0.4"              # framework dep
+See [../README.md](../README.md#prerequisites) for the common HotMem install +
+`hotmem serve` steps. Then install this example's framework deps:
 
-hotmem serve
+```sh
+pip install -e adapters/autogen
+pip install "autogen-agentchat>=0.4"
 ```
 
 ## Run

--- a/examples/autogen_group_chat/chat.py
+++ b/examples/autogen_group_chat/chat.py
@@ -1,0 +1,37 @@
+"""AutoGen group chat with HotMem memory.
+
+Three conversable agents share a HotMemMemoryPlugin. Before each turn the
+plugin recalls relevant context; after each turn the utterance is persisted,
+so later agents inherit earlier ones' context.
+
+Run: hotmem serve  then  python chat.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from hotmem_autogen import HotMemMemoryPlugin
+
+HOTMEM_URL = os.environ.get("HOTMEM_URL", "http://127.0.0.1:8711")
+
+
+def main() -> None:
+    memory = HotMemMemoryPlugin(base_url=HOTMEM_URL, identifier="group-chat")
+
+    memory.save("The project deadline is Friday.", identifier="pm", importance=0.9)
+    print("PM saved: deadline is Friday")
+
+    for speaker, query in [
+        ("engineer", "what is the deadline?"),
+        ("qa", "when should we finish testing?"),
+    ]:
+        context = memory.add_context(query)
+        print(f"{speaker} recalled:\n{context or '(nothing)'}")
+        msg = f"{speaker} plans around the Friday deadline."
+        memory.save(msg, identifier=speaker, importance=0.5)
+        print(f"{speaker} said: {msg}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/crewai_crew/README.md
+++ b/examples/crewai_crew/README.md
@@ -5,12 +5,12 @@ the Writer recalls what the Researcher saved.
 
 ## Setup
 
-```sh
-pip install -e ".[dev,mcp]"
-pip install -e adapters/crewai
-pip install crewai                                # framework dep
+See [../README.md](../README.md#prerequisites) for the common HotMem install +
+`hotmem serve` steps. Then install this example's framework deps:
 
-hotmem serve
+```sh
+pip install -e adapters/crewai
+pip install crewai
 ```
 
 ## Run

--- a/examples/crewai_crew/README.md
+++ b/examples/crewai_crew/README.md
@@ -1,0 +1,20 @@
+# crewai_crew
+
+A 2-agent CrewAI crew (Researcher + Writer) sharing a single HotMem store so
+the Writer recalls what the Researcher saved.
+
+## Setup
+
+```sh
+pip install -e ".[dev,mcp]"
+pip install -e adapters/crewai
+pip install crewai                                # framework dep
+
+hotmem serve
+```
+
+## Run
+
+```sh
+python crew.py
+```

--- a/examples/crewai_crew/crew.py
+++ b/examples/crewai_crew/crew.py
@@ -1,0 +1,44 @@
+"""CrewAI crew with shared HotMem memory.
+
+Researcher saves a finding; Writer recalls it via the same HotMem store,
+demonstrating cross-agent memory continuity without a hand-rolled bus.
+
+Run: hotmem serve  then  python crew.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from hotmem_crewai import HotMemMemory
+
+HOTMEM_URL = os.environ.get("HOTMEM_URL", "http://127.0.0.1:8711")
+
+
+def main() -> None:
+    memory = HotMemMemory(base_url=HOTMEM_URL)
+
+    # Researcher agent stores a finding.
+    memory.save(
+        "Q3 revenue grew 18% driven by enterprise renewals.",
+        identifier="researcher",
+        importance=0.8,
+    )
+    print("Researcher saved: Q3 revenue finding")
+
+    # Writer agent recalls relevant context before drafting.
+    hits = memory.load("revenue growth", top_k=3)
+    context = "\n".join(f"- {h['content']}" for h in hits)
+    print(f"Writer recalled:\n{context}")
+
+    summary = (
+        "Based on the research team's findings, Q3 saw 18% revenue growth, "
+        "primarily from enterprise renewals."
+    )
+    print(f"Writer draft: {summary}")
+
+    memory.save(summary, identifier="writer", importance=0.6)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fastapi_backend/README.md
+++ b/examples/fastapi_backend/README.md
@@ -6,9 +6,12 @@ and `/ask` endpoints.
 
 ## Setup
 
+See [../README.md](../README.md#prerequisites) for the common HotMem install
+steps. This example needs the dev extra (no sidecar required):
+
 ```sh
-pip install fastapi uvicorn
 pip install -e ".[dev]"           # HotMem itself
+pip install fastapi uvicorn
 ```
 
 ## Run

--- a/examples/fastapi_backend/README.md
+++ b/examples/fastapi_backend/README.md
@@ -1,0 +1,28 @@
+# fastapi_backend
+
+A standalone FastAPI app that uses HotMem **as a library** (in-process
+`MemoryDB` + `search_memories`) — no sidecar required. Exposes `/remember`
+and `/ask` endpoints.
+
+## Setup
+
+```sh
+pip install fastapi uvicorn
+pip install -e ".[dev]"           # HotMem itself
+```
+
+## Run
+
+```sh
+uvicorn app:app --port 8000
+```
+
+## Try it
+
+```sh
+curl -s -XPOST localhost:8000/remember -H 'content-type: application/json' \
+  -d '{"identifier":"user-1","fact":"Prefers dark mode"}'
+
+curl -s -XPOST localhost:8000/ask -H 'content-type: application/json' \
+  -d '{"query":"what UI do I like?"}'
+```

--- a/examples/fastapi_backend/app.py
+++ b/examples/fastapi_backend/app.py
@@ -10,6 +10,7 @@ Run: uvicorn app:app --port 8000
 
 from __future__ import annotations
 
+import os
 import tempfile
 from typing import Any
 
@@ -17,11 +18,12 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from hotmem.db import MemoryDB
-from hotmem.embed import embed_text, pack_embedding
 from hotmem.search import search_memories
-from hotmem.swap import compute_content_hash
+from hotmem.swap import add_memory
 
-DB_PATH = tempfile.mktemp(suffix=".sqlite", prefix="hotmem_fastapi_")
+# Private temp dir for the demo DB (atomic creation, no mktemp race).
+_TMP_DIR = tempfile.mkdtemp(prefix="hotmem_fastapi_")
+DB_PATH = os.path.join(_TMP_DIR, "hotmem.sqlite")
 _db = MemoryDB(DB_PATH)
 
 app = FastAPI(title="hotmem-fastapi-example")
@@ -50,20 +52,14 @@ def health() -> dict[str, Any]:
 
 @app.post("/remember")
 def remember(req: RememberRequest) -> dict[str, Any]:
-    import uuid
-
-    blob = pack_embedding(embed_text(req.fact))
-    content_hash = compute_content_hash(req.identifier, req.fact)
-    memory_id = uuid.uuid4().hex
-    _db.insert(
-        id=memory_id,
-        identifier=req.identifier,
-        fact_text=req.fact,
-        embedding=blob,
+    memory_id, content_hash = add_memory(
+        _db,
+        req.identifier,
+        req.fact,
+        source="fastapi-example",
         importance=req.importance,
-        content_hash=content_hash,
     )
-    return {"memory_id": memory_id}
+    return {"memory_id": memory_id, "content_hash": content_hash}
 
 
 @app.post("/ask")

--- a/examples/fastapi_backend/app.py
+++ b/examples/fastapi_backend/app.py
@@ -1,0 +1,75 @@
+"""FastAPI app using HotMem as an in-process library (no sidecar).
+
+Endpoints:
+    POST /remember  {identifier, fact}        -> {memory_id}
+    POST /ask       {query, top_k?}            -> {answer, memories}
+    GET  /health                              -> {memory_count}
+
+Run: uvicorn app:app --port 8000
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from hotmem.db import MemoryDB
+from hotmem.embed import embed_text, pack_embedding
+from hotmem.search import search_memories
+from hotmem.swap import compute_content_hash
+
+DB_PATH = tempfile.mktemp(suffix=".sqlite", prefix="hotmem_fastapi_")
+_db = MemoryDB(DB_PATH)
+
+app = FastAPI(title="hotmem-fastapi-example")
+
+
+class RememberRequest(BaseModel):
+    identifier: str
+    fact: str
+    importance: float = 0.5
+
+
+class AskRequest(BaseModel):
+    query: str
+    top_k: int = 5
+
+
+@app.on_event("shutdown")
+def _shutdown() -> None:
+    _db.close()
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return {"memory_count": _db.count()}
+
+
+@app.post("/remember")
+def remember(req: RememberRequest) -> dict[str, Any]:
+    import uuid
+
+    blob = pack_embedding(embed_text(req.fact))
+    content_hash = compute_content_hash(req.identifier, req.fact)
+    memory_id = uuid.uuid4().hex
+    _db.insert(
+        id=memory_id,
+        identifier=req.identifier,
+        fact_text=req.fact,
+        embedding=blob,
+        importance=req.importance,
+        content_hash=content_hash,
+    )
+    return {"memory_id": memory_id}
+
+
+@app.post("/ask")
+def ask(req: AskRequest) -> dict[str, Any]:
+    memories = search_memories(_db, query=req.query, top_k=req.top_k)
+    return {
+        "memories": memories,
+        "answer": "\n".join(f"- {m['content']}" for m in memories) or "(no memories)",
+    }

--- a/examples/fastapi_backend/requirements.txt
+++ b/examples/fastapi_backend/requirements.txt
@@ -1,0 +1,3 @@
+hotmem>=0.1.9
+fastapi>=0.115
+uvicorn>=0.30

--- a/examples/langchain_agent/README.md
+++ b/examples/langchain_agent/README.md
@@ -1,0 +1,21 @@
+# langchain_agent
+
+A 3-turn LangChain agent that retrieves from HotMem before each response and
+stores new facts afterwards.
+
+## Setup
+
+```sh
+pip install -e ".[dev,mcp]"
+pip install -e adapters/langchain
+pip install langchain langchain-openai          # framework deps
+
+hotmem serve
+export OPENAI_API_KEY=sk-...                     # or use a stub LLM
+```
+
+## Run
+
+```sh
+python agent.py
+```

--- a/examples/langchain_agent/README.md
+++ b/examples/langchain_agent/README.md
@@ -5,13 +5,13 @@ stores new facts afterwards.
 
 ## Setup
 
-```sh
-pip install -e ".[dev,mcp]"
-pip install -e adapters/langchain
-pip install langchain langchain-openai          # framework deps
+See [../README.md](../README.md#prerequisites) for the common HotMem install +
+`hotmem serve` steps. Then install this example's framework deps:
 
-hotmem serve
-export OPENAI_API_KEY=sk-...                     # or use a stub LLM
+```sh
+pip install -e adapters/langchain
+pip install langchain langchain-openai
+export OPENAI_API_KEY=sk-...                     # or use the stub LLM (no key needed)
 ```
 
 ## Run

--- a/examples/langchain_agent/agent.py
+++ b/examples/langchain_agent/agent.py
@@ -1,0 +1,65 @@
+"""LangChain agent with HotMem memory.
+
+A 3-turn loop: recall relevant memories, call the LLM, store any new facts.
+Uses HotMemRetriever (hybrid search) + HotMemChatMessageHistory (turn log).
+
+Run: hotmem serve  then  python agent.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from hotmem_langchain import HotMemRetriever
+
+from hotmem.client import HotMemClient
+
+HOTMEM_URL = os.environ.get("HOTMEM_URL", "http://127.0.0.1:8711")
+IDENTIFIER = "user-42"
+
+
+def get_llm() -> object:
+    """Return a chat LLM. Falls back to a deterministic stub when no API key."""
+    if os.environ.get("OPENAI_API_KEY"):
+        from langchain_openai import ChatOpenAI
+
+        return ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+    from langchain_core.language_models import FakeListChatModel
+
+    return FakeListChatModel(
+        responses=[
+            "Got it — I'll remember you prefer dark mode.",
+            "Based on what I recall, you prefer dark mode. Want me to keep it that way?",
+            "Done. Your preference is saved.",
+        ]
+    )
+
+
+def main() -> None:
+    client = HotMemClient(HOTMEM_URL)
+    retriever = HotMemRetriever(base_url=HOTMEM_URL, top_k=3)
+    llm = get_llm()
+
+    turns = [
+        "Please remember I prefer dark mode.",
+        "What UI theme do I like?",
+        "Thanks, keep it that way.",
+    ]
+
+    for user_text in turns:
+        docs = retriever.invoke(user_text)
+        context = "\n".join(f"- {d.page_content}" for d in docs) or "(no memories yet)"
+        prompt = f"Memories:\n{context}\n\nUser: {user_text}\nAssistant:"
+        reply = llm.invoke(prompt)
+        answer = reply.content if hasattr(reply, "content") else str(reply)
+        print(f"User: {user_text}")
+        print(f"Assistant: {answer}\n")
+
+        # Persist the user's stated fact (heuristic: short declarative turns).
+        if "remember" in user_text.lower() or "prefer" in user_text.lower():
+            client.add(IDENTIFIER, user_text, source="langchain-example")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp_claude_desktop/README.md
+++ b/examples/mcp_claude_desktop/README.md
@@ -5,8 +5,11 @@ your memories as tools.
 
 ## Setup
 
+See [../README.md](../README.md#prerequisites) for the common HotMem install
+steps. This example needs the MCP extra:
+
 ```sh
-pip install -e ".[mcp]"                # HotMem with MCP support
+pip install -e ".[mcp]"
 ```
 
 ## Configure Claude Desktop

--- a/examples/mcp_claude_desktop/README.md
+++ b/examples/mcp_claude_desktop/README.md
@@ -1,0 +1,39 @@
+# mcp_claude_desktop
+
+Wire the HotMem MCP server into Claude Desktop so Claude can add and search
+your memories as tools.
+
+## Setup
+
+```sh
+pip install -e ".[mcp]"                # HotMem with MCP support
+```
+
+## Configure Claude Desktop
+
+Copy the snippet below into your Claude Desktop config:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "hotmem": {
+      "command": "hotmem",
+      "args": ["mcp", "--db", "~/hotmem.sqlite"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The HotMem tools (`add_memory`, `search_memories`,
+`memory_health`, `snapshot`, `hydrate`) are now available.
+
+## Try it
+
+Ask Claude:
+- "Remember that I prefer dark mode and vim keybindings."
+- "What UI preferences have I told you about?"
+
+Claude calls `search_memories` to recall and `add_memory` to persist.

--- a/examples/mcp_claude_desktop/claude_desktop_config.json
+++ b/examples/mcp_claude_desktop/claude_desktop_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hotmem": {
+      "command": "hotmem",
+      "args": ["mcp", "--db", "~/hotmem.sqlite"]
+    }
+  }
+}

--- a/examples/pydanticai_agent/README.md
+++ b/examples/pydanticai_agent/README.md
@@ -5,12 +5,12 @@ and exposes a `remember` tool.
 
 ## Setup
 
-```sh
-pip install -e ".[dev,mcp]"
-pip install -e adapters/pydanticai
-pip install pydantic-ai                           # framework dep
+See [../README.md](../README.md#prerequisites) for the common HotMem install +
+`hotmem serve` steps. Then install this example's framework deps:
 
-hotmem serve
+```sh
+pip install -e adapters/pydanticai
+pip install pydantic-ai
 ```
 
 ## Run

--- a/examples/pydanticai_agent/README.md
+++ b/examples/pydanticai_agent/README.md
@@ -1,0 +1,20 @@
+# pydanticai_agent
+
+A typed Pydantic AI agent that injects HotMem recall into its system prompt
+and exposes a `remember` tool.
+
+## Setup
+
+```sh
+pip install -e ".[dev,mcp]"
+pip install -e adapters/pydanticai
+pip install pydantic-ai                           # framework dep
+
+hotmem serve
+```
+
+## Run
+
+```sh
+python agent.py
+```

--- a/examples/pydanticai_agent/agent.py
+++ b/examples/pydanticai_agent/agent.py
@@ -1,0 +1,51 @@
+"""Pydantic AI agent with HotMem dependency + recall system prompt.
+
+Uses HotMemDeps as the agent's dependency container and recall_system_prompt
+to inject ranked memories into the system prompt each turn. A `remember`
+tool persists new facts.
+
+Run: hotmem serve  then  python agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from hotmem_pydanticai import HotMemDeps, recall_system_prompt
+from pydantic_ai import Agent, RunContext
+
+HOTMEM_URL = os.environ.get("HOTMEM_URL", "http://127.0.0.1:8711")
+
+
+def build_agent() -> Agent[HotMemDeps, str]:
+    agent: Agent[HotMemDeps, str] = Agent("test", deps_type=HotMemDeps)
+    agent.system_prompt(recall_system_prompt)
+
+    @agent.tool
+    async def remember(ctx: RunContext[HotMemDeps], fact: str) -> str:
+        """Persist a fact the user wants remembered."""
+        ctx.deps.client.add(ctx.deps.identifier, fact, source="pydanticai-example")
+        return f"Remembered: {fact}"
+
+    return agent
+
+
+async def main() -> None:
+    deps = HotMemDeps.from_url(HOTMEM_URL, identifier="user-7")
+    agent = build_agent()
+
+    # Seed a memory so recall has something to surface.
+    deps.client.add("user-7", "User prefers concise answers.", source="pydanticai-example")
+
+    for prompt in [
+        "What style of answer do I prefer?",
+        "Remember that I also like examples.",
+    ]:
+        result = await agent.run(prompt, deps=deps)
+        print(f"User: {prompt}")
+        print(f"Agent: {result.output}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,18 @@
+# typescript
+
+Add and search memories from a TypeScript/Node script using the `hotmem` TS
+client against a running sidecar.
+
+## Setup
+
+```sh
+hotmem serve                      # start the sidecar on http://127.0.0.1:8711
+npm install hotmem                # or: npm install -e ../ts  (local build)
+npm install -D tsx                # to run .ts directly
+```
+
+## Run
+
+```sh
+npx tsx agent.ts
+```

--- a/examples/typescript/agent.ts
+++ b/examples/typescript/agent.ts
@@ -1,0 +1,34 @@
+/**
+ * HotMem TypeScript client example: add facts, search, print health.
+ *
+ * Run: hotmem serve  then  npx tsx agent.ts
+ */
+
+import { HotMemClient } from "hotmem";
+
+const BASE_URL = process.env.HOTMEM_URL ?? "http://127.0.0.1:8711";
+
+async function main(): Promise<void> {
+  const client = new HotMemClient(BASE_URL);
+
+  await client.add("vendor_x", "Invoice total $5000", { importance: 0.8 });
+  await client.add("vendor_x", "Prefers email over phone", {
+    source: "intake-call",
+    ttlSeconds: 86400,
+  });
+  console.log("Added 2 memories");
+
+  const memories = await client.search("invoice risk", { topK: 5 });
+  console.log("Search results:");
+  for (const m of memories) {
+    console.log(`  [${m.score}] ${m.identifier}: ${m.content}`);
+  }
+
+  const health = await client.health();
+  console.log(`Health: ${health.memory_count} memories, uptime ${health.uptime_s}s`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ mcp = [
 playground = [
     "rich>=13.7,<14",
 ]
+rich = [
+    "rich>=13.7,<14",
+]
 docs = [
     "mkdocs>=1.6,<2",
     "mkdocs-material>=9.5,<10",
@@ -47,6 +50,7 @@ dev = [
     "pytest>=9,<10",
     "pytest-cov>=6,<7",
     "ruff>=0.15,<1",
+    "rich>=13.7,<14",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hotmem"
-version = "0.1.8"
+version = "0.1.9"
 description = "A local-first memory sidecar for agent applications"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hotmem/__init__.py
+++ b/src/hotmem/__init__.py
@@ -1,3 +1,3 @@
 """HotMem - A local-first memory sidecar for agent applications."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -15,11 +15,13 @@ Extension: add new subcommands (e.g. `hotmem inspect`, `hotmem gc`) here.
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 
 import click
 
 from hotmem.trace import get_tracer
+from hotmem.ui import get_renderer
 
 _trace = get_tracer("cli")
 
@@ -118,11 +120,15 @@ def hydrate(swap_file: str, db_path: str):
     from hotmem.db import MemoryDB
     from hotmem.swap import hydrate as do_hydrate
 
+    ui = get_renderer()
+    total = os.path.getsize(swap_file) if os.path.exists(swap_file) else 0
+
     db = MemoryDB(db_path)
-    result = do_hydrate(db, swap_file)
+    with ui.progress(total=total, desc="Hydrating") as tick:
+        result = do_hydrate(db, swap_file, on_progress=tick)
     db.close()
 
-    click.echo(f"Loaded: {result.loaded}, Skipped dupes: {result.skipped_dupes}")
+    ui.summary("hydrate", loaded=result.loaded, skipped_dupes=result.skipped_dupes)
 
 
 @main.command()
@@ -139,11 +145,14 @@ def snapshot(swap_file: str, db_path: str):
     from hotmem.db import MemoryDB
     from hotmem.swap import snapshot as do_snapshot
 
+    ui = get_renderer()
     db = MemoryDB(db_path)
-    result = do_snapshot(db, swap_file)
+    total = db.count()
+    with ui.progress(total=total, desc="Snapshotting") as tick:
+        result = do_snapshot(db, swap_file, on_progress=tick)
     db.close()
 
-    click.echo(f"Exported: {result.exported} → {result.path}")
+    ui.summary("snapshot", exported=result.exported, path=result.path)
 
 
 @main.command()
@@ -153,17 +162,68 @@ def status(port: int, host: str):
     """Check if a HotMem server is running."""
     import httpx
 
+    ui = get_renderer()
     url = f"http://{host}:{port}/v1/health"
     try:
         resp = httpx.get(url, timeout=3.0)
         data = resp.json()
-        click.echo(f"Status: {data['status']}")
-        click.echo(f"Memories: {data['memory_count']}")
-        click.echo(f"DB: {data['db_path']}")
-        click.echo(f"Uptime: {data['uptime_s']}s")
+        ui.status(data)
     except httpx.ConnectError as err:
         click.echo(f"No HotMem server found at {url}", err=True)
         raise SystemExit(1) from err
+
+
+@main.command()
+@click.argument("query")
+@click.option("--db", "db_path", default=None, type=click.Path(), help="Database file path.")
+@click.option("--url", default=None, help="Running server URL (e.g. http://127.0.0.1:8711).")
+@click.option("--top-k", "top_k", default=5, type=int, help="Maximum results.")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit raw JSON (bypasses the renderer, for scripting).",
+)
+def search(query: str, db_path: str | None, url: str | None, top_k: int, as_json: bool):
+    """Search memories and print formatted results with scores."""
+    rows = _run_search(query, db_path=db_path, url=url, top_k=top_k)
+
+    if as_json:
+        click.echo(json.dumps(rows, indent=2, default=str))
+        return
+
+    get_renderer().search_results(rows)
+
+
+def _run_search(
+    query: str,
+    *,
+    db_path: str | None,
+    url: str | None,
+    top_k: int,
+) -> list[dict]:
+    """Resolve backend (HTTP server or local DB) and return search rows."""
+    if url is not None:
+        import httpx
+
+        resp = httpx.post(
+            f"{url.rstrip('/')}/v1/search",
+            json={"query": query, "top_k": top_k},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        return resp.json()["memories"]
+
+    from hotmem.db import MemoryDB
+    from hotmem.search import search_memories
+
+    if not db_path:
+        raise click.ClickException("search requires --db PATH or --url URL")
+    db = MemoryDB(db_path)
+    try:
+        return search_memories(db, query=query, top_k=top_k)
+    finally:
+        db.close()
 
 
 @main.command()

--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -122,7 +122,10 @@ def hydrate(swap_file: str, db_path: str):
     from hotmem.swap import hydrate as do_hydrate
 
     ui = get_renderer()
-    total = os.path.getsize(swap_file) if os.path.exists(swap_file) else 0
+    # For .jsonl.gz the on-disk (compressed) size != uncompressed bytes advanced
+    # by on_progress, so the byte bar would overshoot; use indeterminate instead.
+    is_gz = swap_file.lower().endswith(".gz")
+    total = None if is_gz else (os.path.getsize(swap_file) if os.path.exists(swap_file) else 0)
 
     db = MemoryDB(db_path)
     with ui.progress(total=total, desc="Hydrating") as tick:
@@ -335,7 +338,7 @@ def import_cmd(source: str, source_db: str, target_db: str | None, swap_out: str
         try:
             # Reading phase: indeterminate progress (we don't know the row
             # count up front); the byte-total bar applies to the hydrate phase.
-            with open(swap_path, "w") as f, ui.progress(total=None, desc="Reading source") as _tick:
+            with open(swap_path, "w") as f, ui.progress(total=None, desc="Reading source"):
                 for record in reader(_Path(source_db)):
                     write_record(f, record)
         except (ValueError, FileNotFoundError) as err:

--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -204,16 +204,13 @@ def _run_search(
     top_k: int,
 ) -> list[dict]:
     """Resolve backend (HTTP server or local DB) and return search rows."""
-    if url is not None:
-        import httpx
+    if url is not None and db_path is not None:
+        raise click.ClickException("pass either --db or --url, not both")
 
-        resp = httpx.post(
-            f"{url.rstrip('/')}/v1/search",
-            json={"query": query, "top_k": top_k},
-            timeout=30.0,
-        )
-        resp.raise_for_status()
-        return resp.json()["memories"]
+    if url is not None:
+        from hotmem.client import HotMemClient
+
+        return HotMemClient(url).search(query, top_k=top_k)
 
     from hotmem.db import MemoryDB
     from hotmem.search import search_memories
@@ -319,28 +316,38 @@ def import_cmd(source: str, source_db: str, target_db: str | None, swap_out: str
     from hotmem.db import MemoryDB
     from hotmem.importers import IMPORTERS
     from hotmem.swap import hydrate as do_hydrate
+    from hotmem.swap import write_record
 
     reader = IMPORTERS[source.lower()]
 
     ui = get_renderer()
-    swap_path = swap_out or _tempfile.mktemp(suffix=".jsonl", prefix="hotmem_import_")
-    cleanup = swap_out is None
+
+    # Use a private temp dir for transient artifacts so both the swap JSONL
+    # and the target DB are cleaned up atomically and never leave predictable
+    # paths on disk. mkdtemp creates the dir atomically (no mktemp race).
+    tmp_dir = _tempfile.mkdtemp(prefix="hotmem_import_")
+    swap_keep = swap_out is not None
+    target_keep = target_db is not None
+    swap_path = swap_out or os.path.join(tmp_dir, "import.jsonl")
+    target = target_db or os.path.join(tmp_dir, "hotmem.sqlite")
 
     try:
         try:
-            with open(swap_path, "w") as f, ui.progress(total=0, desc="Reading source") as tick:
+            # Reading phase: indeterminate progress (we don't know the row
+            # count up front); the byte-total bar applies to the hydrate phase.
+            with open(swap_path, "w") as f, ui.progress(total=None, desc="Reading source") as _tick:
                 for record in reader(_Path(source_db)):
-                    f.write(json.dumps(record, default=str) + "\n")
-                    tick(1)
+                    write_record(f, record)
         except (ValueError, FileNotFoundError) as err:
             raise click.ClickException(f"import from {source} failed: {err}") from err
 
-        target = target_db or _tempfile.mktemp(suffix=".sqlite", prefix="hotmem_")
         db = MemoryDB(target)
-        total = os.path.getsize(swap_path) if os.path.exists(swap_path) else 0
-        with ui.progress(total=total, desc="Hydrating") as tick:
-            result = do_hydrate(db, swap_path, on_progress=tick)
-        db.close()
+        try:
+            total = os.path.getsize(swap_path) if os.path.exists(swap_path) else 0
+            with ui.progress(total=total, desc="Hydrating") as tick:
+                result = do_hydrate(db, swap_path, on_progress=tick)
+        finally:
+            db.close()
 
         ui.summary(
             "import",
@@ -350,5 +357,11 @@ def import_cmd(source: str, source_db: str, target_db: str | None, swap_out: str
             target=target,
         )
     finally:
-        if cleanup and os.path.exists(swap_path):
+        # Clean up transient artifacts. Kept paths (--out / --target) survive.
+        if not swap_keep and os.path.exists(swap_path):
             os.remove(swap_path)
+        if not target_keep and os.path.exists(target):
+            os.remove(target)
+        # Remove the temp dir if empty (kept artifacts may live elsewhere).
+        if os.path.isdir(tmp_dir) and not os.listdir(tmp_dir):
+            os.rmdir(tmp_dir)

--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from pathlib import Path as _Path
 
 import click
 
@@ -275,3 +276,79 @@ def playground(db_path: str | None, url: str | None):
         raise click.ClickException(str(err)) from err
     except ValueError as err:
         raise click.ClickException(str(err)) from err
+
+
+@main.command("import")
+@click.option(
+    "--from",
+    "source",
+    required=True,
+    type=click.Choice(["mem0"], case_sensitive=False),
+    help="Source memory system to import from.",
+)
+@click.option(
+    "--db",
+    "source_db",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the source memory database (e.g. mem0's history SQLite DB).",
+)
+@click.option(
+    "--target",
+    "target_db",
+    default=None,
+    type=click.Path(),
+    help="HotMem database to hydrate into. Defaults to a temp DB.",
+)
+@click.option(
+    "--out",
+    "swap_out",
+    default=None,
+    type=click.Path(),
+    help="Keep the intermediate HotMem swap JSONL at this path (default: temp, deleted).",
+)
+def import_cmd(source: str, source_db: str, target_db: str | None, swap_out: str | None):
+    """Import memories from a foreign memory system into HotMem.
+
+    One-command migration: read the source store, convert to HotMem swap JSONL,
+    hydrate into the target DB. Embeddings are re-computed by HotMem's
+    embedder (source dims differ, so reuse is not possible).
+    """
+    import tempfile as _tempfile
+
+    from hotmem.db import MemoryDB
+    from hotmem.importers import IMPORTERS
+    from hotmem.swap import hydrate as do_hydrate
+
+    reader = IMPORTERS[source.lower()]
+
+    ui = get_renderer()
+    swap_path = swap_out or _tempfile.mktemp(suffix=".jsonl", prefix="hotmem_import_")
+    cleanup = swap_out is None
+
+    try:
+        try:
+            with open(swap_path, "w") as f, ui.progress(total=0, desc="Reading source") as tick:
+                for record in reader(_Path(source_db)):
+                    f.write(json.dumps(record, default=str) + "\n")
+                    tick(1)
+        except (ValueError, FileNotFoundError) as err:
+            raise click.ClickException(f"import from {source} failed: {err}") from err
+
+        target = target_db or _tempfile.mktemp(suffix=".sqlite", prefix="hotmem_")
+        db = MemoryDB(target)
+        total = os.path.getsize(swap_path) if os.path.exists(swap_path) else 0
+        with ui.progress(total=total, desc="Hydrating") as tick:
+            result = do_hydrate(db, swap_path, on_progress=tick)
+        db.close()
+
+        ui.summary(
+            "import",
+            source=source,
+            imported=result.loaded,
+            skipped_dupes=result.skipped_dupes,
+            target=target,
+        )
+    finally:
+        if cleanup and os.path.exists(swap_path):
+            os.remove(swap_path)

--- a/src/hotmem/importers/__init__.py
+++ b/src/hotmem/importers/__init__.py
@@ -1,0 +1,36 @@
+"""HotMem importers — pluggable converters from foreign memory stores.
+
+Purpose:
+    Provide a registry of importers that read an external memory system's
+    on-disk format and yield HotMem swap-record dicts (identifier, fact_text,
+    created_at, source, ...). The CLI `hotmem import` command dispatches
+    through this registry so new importers plug in without CLI changes.
+
+Interface:
+    IMPORTERS: dict[str, Callable[[Path], Iterator[dict]]]
+    register(name, fn) -> None   # extension point for third-party importers
+
+Deps: stdlib only at the package level; individual importer modules may
+import their own (optional) deps lazily.
+
+Extension: add a new module under importers/, implement a reader that yields
+swap-record dicts, and register it here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+from hotmem.importers.mem0 import read_mem0_sqlite
+
+ImporterFn = Callable[[Path], Iterator[dict]]
+
+IMPORTERS: dict[str, ImporterFn] = {
+    "mem0": read_mem0_sqlite,
+}
+
+
+def register(name: str, fn: ImporterFn) -> None:
+    """Register a third-party importer under `name`."""
+    IMPORTERS[name] = fn

--- a/src/hotmem/importers/mem0.py
+++ b/src/hotmem/importers/mem0.py
@@ -1,0 +1,125 @@
+"""mem0 importer — read a mem0 SQLite history DB and yield HotMem swap records.
+
+Purpose:
+    Convert the canonical, always-present mem0 storage format (the SQLite
+    `history` table written by mem0.SQLiteManager) into HotMem swap-record
+    dicts so `swap.hydrate` can ingest them in one command.
+
+    mem0's vector store (Qdrant/Chroma/...) holds embeddings at dimensions
+    that differ from HotMem's, so embeddings are intentionally NOT reused —
+    hydrate re-embeds with HotMem's embedder, identical to the JSONL path
+    with no stored embedding. The history table has the same text + identity
+    + timestamps, requires no extra client libs, and is a single file.
+
+Interface:
+    read_mem0_sqlite(path, on_progress=None) -> Iterator[dict]
+
+Deps: stdlib sqlite3 only.
+
+Extension: add readers for other mem0 backends (qdrant dump, chroma sqlite)
+in sibling modules.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+from hotmem.trace import get_tracer
+
+_trace = get_tracer("importers.mem0")
+
+_MEM0_HISTORY_COLUMNS = {
+    "id",
+    "memory_id",
+    "old_memory",
+    "new_memory",
+    "event",
+    "created_at",
+    "updated_at",
+    "is_deleted",
+    "actor_id",
+    "role",
+}
+
+_SELECT_SQL = """
+    SELECT new_memory, actor_id, created_at, id
+    FROM history
+    WHERE event = 'ADD'
+      AND is_deleted = 0
+      AND new_memory IS NOT NULL
+      AND new_memory != ''
+"""
+
+
+def _validate_mem0_schema(conn: sqlite3.Connection) -> None:
+    """Raise ValueError if the DB does not look like a mem0 history DB."""
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='history'"
+        ).fetchall()
+    except sqlite3.DatabaseError as err:
+        raise ValueError(f"not a SQLite database: {err}") from err
+
+    if not rows:
+        raise ValueError("no 'history' table found; this does not appear to be a mem0 SQLite DB")
+
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(history)").fetchall()}
+    missing = _MEM0_HISTORY_COLUMNS - cols
+    if missing:
+        raise ValueError(f"history table is missing expected mem0 columns: {sorted(missing)}")
+
+
+def read_mem0_sqlite(
+    path: Path,
+    *,
+    on_progress: Callable[[int], None] | None = None,
+) -> Iterator[dict]:
+    """Yield HotMem swap-record dicts from a mem0 SQLite history DB.
+
+    Only rows with event='ADD' and is_deleted=0 are emitted (live memories).
+    Maps:
+        new_memory  -> fact_text
+        actor_id    -> identifier  (falls back to "mem0" when NULL/empty)
+        created_at  -> created_at
+        source      -> "mem0"
+        id          -> id  (mem0 history row id, reused as HotMem memory id)
+
+    on_progress, if given, is invoked once per yielded row with the 1-based
+    row count, enabling byte/row-based progress reporting without coupling
+    this module to any UI library.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"mem0 source DB not found: {path}")
+
+    conn = sqlite3.connect(str(path))
+    try:
+        _validate_mem0_schema(conn)
+        cursor = conn.execute(_SELECT_SQL)
+        count = 0
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            new_memory, actor_id, created_at, row_id = row
+            identifier = actor_id or "mem0"
+            count += 1
+            yield {
+                "id": row_id,
+                "identifier": identifier,
+                "fact_text": new_memory,
+                "source": "mem0",
+                "created_at": created_at,
+            }
+            if on_progress is not None:
+                on_progress(count)
+    finally:
+        conn.close()
+
+    _trace.info(
+        "importers.mem0",
+        f"read {count} live memories from mem0 history DB",
+        detail={"path": str(path), "count": count},
+    )

--- a/src/hotmem/importers/mem0.py
+++ b/src/hotmem/importers/mem0.py
@@ -11,6 +11,11 @@ Purpose:
     with no stored embedding. The history table has the same text + identity
     + timestamps, requires no extra client libs, and is a single file.
 
+    mem0's history is an audit log: ADD creates a memory, UPDATE records a
+    new current text (the original ADD row is left untouched), DELETE marks
+    the memory gone. To import the *current* state we replay events per
+    memory_id in created_at order and emit one record per live memory_id.
+
 Interface:
     read_mem0_sqlite(path, on_progress=None) -> Iterator[dict]
 
@@ -43,13 +48,14 @@ _MEM0_HISTORY_COLUMNS = {
     "role",
 }
 
-_SELECT_SQL = """
-    SELECT new_memory, actor_id, created_at, id
+# Replay history per memory_id in deterministic order. created_at may tie, so
+# the row id is the tiebreaker. Ordering by memory_id first lets us stream
+# the replay one memory at a time rather than loading the whole table.
+_REPLAY_SQL = """
+    SELECT memory_id, new_memory, event, is_deleted, actor_id, created_at, id
     FROM history
-    WHERE event = 'ADD'
-      AND is_deleted = 0
-      AND new_memory IS NOT NULL
-      AND new_memory != ''
+    WHERE memory_id IS NOT NULL
+    ORDER BY memory_id, created_at, id
 """
 
 
@@ -76,50 +82,94 @@ def read_mem0_sqlite(
     *,
     on_progress: Callable[[int], None] | None = None,
 ) -> Iterator[dict]:
-    """Yield HotMem swap-record dicts from a mem0 SQLite history DB.
+    """Yield HotMem swap-record dicts representing the *current* state of a mem0 DB.
 
-    Only rows with event='ADD' and is_deleted=0 are emitted (live memories).
-    Maps:
+    Replays the audit log per memory_id in created_at order: ADD/UPDATE set the
+    current text, DELETE removes the memory. Emits one record per live
+    memory_id with its latest non-empty new_memory. Rows whose latest event is
+    a DELETE, or whose latest new_memory is NULL/empty, are skipped.
+
+    Maps (from the latest live row per memory_id):
         new_memory  -> fact_text
         actor_id    -> identifier  (falls back to "mem0" when NULL/empty)
         created_at  -> created_at
         source      -> "mem0"
-        id          -> id  (mem0 history row id, reused as HotMem memory id)
 
-    on_progress, if given, is invoked once per yielded row with the 1-based
-    row count, enabling byte/row-based progress reporting without coupling
-    this module to any UI library.
+    HotMem memory ids are intentionally NOT carried from mem0 — hydrate
+    auto-generates uuid4 ids and dedups on content_hash, so re-import is
+    idempotent and foreign PK collisions cannot silently drop memories.
+
+    on_progress, if given, is invoked once per yielded record with the
+    1-based count.
     """
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"mem0 source DB not found: {path}")
 
     conn = sqlite3.connect(str(path))
+    count = 0
     try:
         _validate_mem0_schema(conn)
-        cursor = conn.execute(_SELECT_SQL)
-        count = 0
+        cursor = conn.execute(_REPLAY_SQL)
+
+        current_memory_id: str | None = None
+        current_text: str | None = None
+        current_actor: str | None = None
+        current_created: str | None = None
+        current_live = False
+
+        def _flush() -> Iterator[dict]:
+            nonlocal count
+            if (
+                current_memory_id is not None
+                and current_live
+                and current_text
+                and current_text.strip()
+            ):
+                count += 1
+                yield {
+                    "identifier": current_actor or "mem0",
+                    "fact_text": current_text,
+                    "source": "mem0",
+                    "created_at": current_created,
+                }
+                if on_progress is not None:
+                    on_progress(count)
+
         while True:
             row = cursor.fetchone()
             if row is None:
+                yield from _flush()
                 break
-            new_memory, actor_id, created_at, row_id = row
-            identifier = actor_id or "mem0"
-            count += 1
-            yield {
-                "id": row_id,
-                "identifier": identifier,
-                "fact_text": new_memory,
-                "source": "mem0",
-                "created_at": created_at,
-            }
-            if on_progress is not None:
-                on_progress(count)
+
+            memory_id, new_memory, event, is_deleted, actor_id, created_at, _row_id = row
+
+            if current_memory_id is not None and memory_id != current_memory_id:
+                yield from _flush()
+                current_text = None
+                current_actor = None
+                current_created = None
+                current_live = False
+
+            current_memory_id = memory_id
+            # Replay: latest non-DELETE event wins. is_deleted on the row is
+            # also honored so a row marked deleted (even with event='ADD')
+            # removes the memory.
+            if event == "DELETE" or is_deleted:
+                current_live = False
+                current_text = None
+            else:
+                # ADD or UPDATE: adopt this row's text/identity/timestamp.
+                if new_memory is not None and new_memory.strip():
+                    current_text = new_memory
+                    current_actor = actor_id
+                    current_created = created_at
+                current_live = True
     finally:
         conn.close()
 
     _trace.info(
         "importers.mem0",
-        f"read {count} live memories from mem0 history DB",
+        f"replayed mem0 history, emitted {count} live memories",
         detail={"path": str(path), "count": count},
     )

--- a/src/hotmem/swap.py
+++ b/src/hotmem/swap.py
@@ -21,7 +21,7 @@ import gzip
 import hashlib
 import json
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -114,12 +114,21 @@ def _stored_embedding(record: dict) -> bytes | None:
     return blob
 
 
-def hydrate(db: MemoryDB, swap_path: str | Path) -> HydrateResult:
+def hydrate(
+    db: MemoryDB,
+    swap_path: str | Path,
+    *,
+    on_progress: Callable[[int], None] | None = None,
+) -> HydrateResult:
     """Load memories from a swap file into the database.
 
     Accepts JSONL, JSONL.GZ, or a HotMem SQLite database (.sqlite/.db).
     Deduplicates by content_hash - skips rows that already exist in the DB.
     For SQLite sources, embeddings are reused as-is (fast-path, no recompute).
+
+    on_progress, if given, is invoked once per parsed line with the byte
+    length of that line — enabling byte-based progress reporting without
+    coupling swap.py to any UI library.
     """
     swap_path = Path(swap_path)
     if not swap_path.exists():
@@ -142,12 +151,17 @@ def hydrate(db: MemoryDB, swap_path: str | Path) -> HydrateResult:
         try:
             with _open_swap_read(swap_path) as f:
                 for line in f:
-                    bytes_read += len(line.encode())
+                    line_bytes_len = len(line.encode())
+                    bytes_read += line_bytes_len
                     line = line.strip()
                     if not line:
+                        if on_progress is not None:
+                            on_progress(line_bytes_len)
                         continue
                     record = json.loads(line)
                     parsed += 1
+                    if on_progress is not None:
+                        on_progress(line_bytes_len)
 
                     identifier = record.get("identifier", "")
                     fact_text = record.get("fact_text", "")
@@ -214,18 +228,25 @@ def snapshot(
     swap_path: str | Path,
     *,
     include_embeddings: bool = True,
+    on_progress: Callable[[int], None] | None = None,
 ) -> SnapshotResult:
-    """Export all memories from the database to a JSONL or JSONL.GZ swap file."""
+    """Export all memories from the database to a JSONL or JSONL.GZ swap file.
+
+    on_progress, if given, is invoked once per exported row with the count of
+    rows written so far (cumulative).
+    """
     swap_path = Path(swap_path)
 
     with Timer() as t:
         rows = db.all_rows(include_embedding=include_embeddings)
         with _open_swap_write(swap_path) as f:
-            for row in rows:
+            for i, row in enumerate(rows, 1):
                 embedding = row.pop("embedding", None)
                 if embedding is not None:
                     row["embedding_b64"] = base64.b64encode(embedding).decode("ascii")
                 f.write(json.dumps(row, default=str) + "\n")
+                if on_progress is not None:
+                    on_progress(i)
 
     _trace.info(
         "snapshot",

--- a/src/hotmem/swap.py
+++ b/src/hotmem/swap.py
@@ -232,6 +232,44 @@ def write_record(f: TextIO, record: dict) -> None:
     f.write(json.dumps(record, default=str) + "\n")
 
 
+def add_memory(
+    db: MemoryDB,
+    identifier: str,
+    fact: str,
+    *,
+    source: str = "",
+    importance: float = 0.5,
+    metadata: dict | None = None,
+    ttl_seconds: int | None = None,
+) -> tuple[str, str]:
+    """Insert one memory into the DB using the canonical add contract.
+
+    Centralizes the uuid → content_hash → embed → pack → insert sequence so
+    callers (server, mcp, playground, examples) cannot drift apart. Returns
+    (memory_id, content_hash).
+    """
+    import uuid
+
+    memory_id = uuid.uuid4().hex
+    content_hash = compute_content_hash(identifier, fact)
+    vec = embed_text(fact)
+    blob = pack_embedding(vec)
+    db.insert(
+        id=memory_id,
+        identifier=identifier,
+        fact_text=fact,
+        embedding=blob,
+        embedding_dim=EMBEDDING_DIM,
+        embedding_model=EMBEDDING_MODEL,
+        source=source,
+        importance=importance,
+        metadata_json=json.dumps(metadata or {}),
+        content_hash=content_hash,
+        ttl_seconds=ttl_seconds,
+    )
+    return memory_id, content_hash
+
+
 def snapshot(
     db: MemoryDB,
     swap_path: str | Path,

--- a/src/hotmem/swap.py
+++ b/src/hotmem/swap.py
@@ -223,6 +223,15 @@ def hydrate(
     return HydrateResult(loaded=loaded, skipped_dupes=skipped)
 
 
+def write_record(f: TextIO, record: dict) -> None:
+    """Serialize one swap record to a JSONL file handle.
+
+    Centralizes the swap-record serialization contract (json + default=str +
+    trailing newline) so callers (snapshot, import) cannot drift apart.
+    """
+    f.write(json.dumps(record, default=str) + "\n")
+
+
 def snapshot(
     db: MemoryDB,
     swap_path: str | Path,
@@ -244,7 +253,7 @@ def snapshot(
                 embedding = row.pop("embedding", None)
                 if embedding is not None:
                     row["embedding_b64"] = base64.b64encode(embedding).decode("ascii")
-                f.write(json.dumps(row, default=str) + "\n")
+                write_record(f, row)
                 if on_progress is not None:
                     on_progress(i)
 

--- a/src/hotmem/ui.py
+++ b/src/hotmem/ui.py
@@ -1,0 +1,174 @@
+"""HotMem UI — rendering seam for CLI output.
+
+Purpose:
+    Provide a single conditional surface for CLI output so that `rich` stays
+    optional and the rest of the codebase never branches on renderer choice.
+
+Interface:
+    get_renderer() -> Renderer           # factory, picks Rich or Plain
+    Renderer.status(data)                # health/summary panel
+    Renderer.search_results(rows)        # formatted search hits with scores
+    Renderer.progress(total, desc)        # context manager yielding tick(n)
+    Renderer.summary(label, **kv)         # final one-line summary
+
+Deps: click (always), rich (optional, lazy-imported at construction only)
+
+Extension: add a JSON renderer or a batch/log renderer by extending the
+factory.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import click
+
+
+def _rich_available() -> bool:
+    try:
+        import rich  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _use_rich() -> bool:
+    """Decide whether the RichRenderer is appropriate for this process."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    if not sys.stdout.isatty():
+        return False
+    return _rich_available()
+
+
+def get_renderer() -> Renderer:
+    """Return the best renderer for the current environment."""
+    if _use_rich():
+        return RichRenderer()
+    return PlainRenderer()
+
+
+class Renderer:
+    """Protocol shared by Plain and Rich renderers."""
+
+    def status(self, data: dict[str, Any]) -> None: ...
+
+    def search_results(self, rows: list[dict[str, Any]]) -> None: ...
+
+    @contextmanager
+    def progress(self, total: int, desc: str = "") -> Iterator[Callable[[int], None]]: ...
+
+    def summary(self, label: str, **kv: Any) -> None: ...
+
+
+class PlainRenderer(Renderer):
+    """Plain-text renderer — used when rich is absent or output is piped."""
+
+    def status(self, data: dict[str, Any]) -> None:
+        for key in ("status", "memory_count", "db_path", "uptime_s"):
+            if key in data:
+                click.echo(f"{key.replace('_', ' ').title()}: {data[key]}")
+
+    def search_results(self, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            click.echo("No memories found.")
+            return
+        for i, row in enumerate(rows, 1):
+            score = row.get("score", "")
+            ident = row.get("identifier", "")
+            content = row.get("content", "")
+            click.echo(f"{i}. [{score}] {ident}: {content}")
+
+    @contextmanager
+    def progress(self, total: int, desc: str = "") -> Iterator[Callable[[int], None]]:
+        # Silent: no progress output when not a TTY / rich absent.
+        def tick(_n: int = 0) -> None:
+            pass
+
+        yield tick
+
+    def summary(self, label: str, **kv: Any) -> None:
+        parts = [f"{k}={v}" for k, v in kv.items()]
+        click.echo(f"{label}: " + ", ".join(parts)) if parts else click.echo(label)
+
+
+class RichRenderer(Renderer):
+    """Colored renderer backed by the optional `rich` dependency."""
+
+    def __init__(self) -> None:
+        from rich.console import Console
+
+        self._console = Console()
+
+    def status(self, data: dict[str, Any]) -> None:
+        from rich.panel import Panel
+        from rich.table import Table
+
+        table = Table.grid(padding=(0, 1))
+        table.add_column(style="cyan")
+        table.add_column()
+        for key in ("status", "memory_count", "db_path", "uptime_s"):
+            if key in data:
+                table.add_row(key.replace("_", " ").title(), str(data[key]))
+        self._console.print(Panel(table, title="hotmem status", border_style="green"))
+
+    def search_results(self, rows: list[dict[str, Any]]) -> None:
+        from rich.table import Table
+
+        if not rows:
+            self._console.print("[dim]No memories found.[/dim]")
+            return
+        table = Table(title="Search results", show_lines=False)
+        table.add_column("#", style="dim", width=3)
+        table.add_column("score", justify="right", style="yellow")
+        table.add_column("identifier", style="cyan")
+        table.add_column("content", overflow="fold")
+        for i, row in enumerate(rows, 1):
+            table.add_row(
+                str(i),
+                str(row.get("score", "")),
+                str(row.get("identifier", "")),
+                str(row.get("content", "")),
+            )
+        self._console.print(table)
+
+    @contextmanager
+    def progress(self, total: int, desc: str = "") -> Iterator[Callable[[int], None]]:
+        from rich.progress import (
+            BarColumn,
+            DownloadColumn,
+            Progress,
+            TextColumn,
+            TimeRemainingColumn,
+            TransferSpeedColumn,
+        )
+
+        prog = Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+            console=self._console,
+        )
+        prog.start()
+        try:
+            task_id = prog.add_task(desc, total=max(total, 1))
+
+            def tick(n: int = 1) -> None:
+                prog.update(task_id, advance=n)
+
+            yield tick
+        finally:
+            prog.stop()
+
+    def summary(self, label: str, **kv: Any) -> None:
+        parts = [f"[bold]{k}[/bold]=[green]{v}[/green]" for k, v in kv.items()]
+        line = f"{label}: " + ", ".join(parts) if parts else label
+        self._console.print(line)

--- a/src/hotmem/ui.py
+++ b/src/hotmem/ui.py
@@ -27,6 +27,10 @@ from typing import Any
 
 import click
 
+# Canonical /v1/health payload keys, in display order. Hoisted so both
+# renderers iterate the same contract — adding a health field only edits here.
+_STATUS_KEYS = ("status", "memory_count", "db_path", "uptime_s")
+
 
 def _rich_available() -> bool:
     try:
@@ -62,7 +66,7 @@ class Renderer:
     def search_results(self, rows: list[dict[str, Any]]) -> None: ...
 
     @contextmanager
-    def progress(self, total: int, desc: str = "") -> Iterator[Callable[[int], None]]: ...
+    def progress(self, total: int | None, desc: str = "") -> Iterator[Callable[[int], None]]: ...
 
     def summary(self, label: str, **kv: Any) -> None: ...
 
@@ -71,7 +75,7 @@ class PlainRenderer(Renderer):
     """Plain-text renderer — used when rich is absent or output is piped."""
 
     def status(self, data: dict[str, Any]) -> None:
-        for key in ("status", "memory_count", "db_path", "uptime_s"):
+        for key in _STATUS_KEYS:
             if key in data:
                 click.echo(f"{key.replace('_', ' ').title()}: {data[key]}")
 
@@ -86,7 +90,7 @@ class PlainRenderer(Renderer):
             click.echo(f"{i}. [{score}] {ident}: {content}")
 
     @contextmanager
-    def progress(self, total: int, desc: str = "") -> Iterator[Callable[[int], None]]:
+    def progress(self, total: int | None, desc: str = "") -> Iterator[Callable[[int], None]]:
         # Silent: no progress output when not a TTY / rich absent.
         def tick(_n: int = 0) -> None:
             pass
@@ -113,7 +117,7 @@ class RichRenderer(Renderer):
         table = Table.grid(padding=(0, 1))
         table.add_column(style="cyan")
         table.add_column()
-        for key in ("status", "memory_count", "db_path", "uptime_s"):
+        for key in _STATUS_KEYS:
             if key in data:
                 table.add_row(key.replace("_", " ").title(), str(data[key]))
         self._console.print(Panel(table, title="hotmem status", border_style="green"))
@@ -139,27 +143,36 @@ class RichRenderer(Renderer):
         self._console.print(table)
 
     @contextmanager
-    def progress(self, total: int, desc: str = "") -> Iterator[Callable[[int], None]]:
+    def progress(self, total: int | None, desc: str = "") -> Iterator[Callable[[int], None]]:
         from rich.progress import (
             BarColumn,
             DownloadColumn,
             Progress,
+            SpinnerColumn,
             TextColumn,
             TimeRemainingColumn,
             TransferSpeedColumn,
         )
 
-        prog = Progress(
-            TextColumn("[bold blue]{task.description}"),
-            BarColumn(),
-            DownloadColumn(),
-            TransferSpeedColumn(),
-            TimeRemainingColumn(),
-            console=self._console,
-        )
+        if total is None:
+            # Indeterminate: spinner + description, no byte/ETA columns.
+            prog = Progress(
+                SpinnerColumn(),
+                TextColumn("[bold blue]{task.description}"),
+                console=self._console,
+            )
+        else:
+            prog = Progress(
+                TextColumn("[bold blue]{task.description}"),
+                BarColumn(),
+                DownloadColumn(),
+                TransferSpeedColumn(),
+                TimeRemainingColumn(),
+                console=self._console,
+            )
         prog.start()
         try:
-            task_id = prog.add_task(desc, total=max(total, 1))
+            task_id = prog.add_task(desc, total=total if total is not None else None)
 
             def tick(n: int = 1) -> None:
                 prog.update(task_id, advance=n)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,21 @@ def test_hydrate_progress_runs_without_error_when_piped(tmp_path: Path):
     assert result.exit_code == 0
 
 
+def test_hydrate_gzipped_swap_uses_indeterminate_progress(tmp_path: Path):
+    """Gzipped swap uses total=None (compressed size != uncompressed bytes)."""
+    import gzip
+
+    swap = tmp_path / "swap.jsonl.gz"
+    with gzip.open(swap, "wt") as f:
+        f.write('{"identifier": "a", "fact_text": "gz fact one"}\n')
+        f.write('{"identifier": "b", "fact_text": "gz fact two"}\n')
+    runner = CliRunner()
+    db_path = str(tmp_path / "d.sqlite")
+    result = runner.invoke(main, ["hydrate", "--file", str(swap), "--db", db_path])
+    assert result.exit_code == 0, result.output
+    assert "loaded=2" in result.output
+
+
 # ── snapshot ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,188 @@
+"""Tests for hotmem.cli — rich CLI output (ticket #16).
+
+All assertions target the PlainRenderer path (NO_COLOR=1, non-TTY) so output
+is deterministic in CI/headless environments.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from hotmem.cli import main
+from hotmem.db import MemoryDB
+from hotmem.embed import embed_text, pack_embedding
+from hotmem.ui import PlainRenderer
+
+
+@pytest.fixture(autouse=True)
+def _force_plain(monkeypatch: pytest.MonkeyPatch):
+    """Every test in this file runs against the PlainRenderer."""
+    import hotmem.ui as ui
+
+    monkeypatch.setattr(ui, "_use_rich", lambda: False)
+
+
+# ── status ─────────────────────────────────────────────────────────────
+
+
+def test_status_up_prints_health_fields():
+    runner = CliRunner()
+    payload = {"status": "ok", "memory_count": 7, "db_path": "/tmp/x.sqlite", "uptime_s": 1.2}
+    with mock.patch("httpx.get") as g:
+        g.return_value = mock.Mock(json=lambda: payload)
+        result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "ok" in out
+    assert "7" in out
+    assert "/tmp/x.sqlite" in out
+    assert "1.2" in out
+
+
+def test_status_down_exits_nonzero():
+    runner = CliRunner()
+    import httpx
+
+    with mock.patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+        result = runner.invoke(main, ["status"])
+    assert result.exit_code == 1
+    assert "No HotMem server" in result.output
+
+
+# ── hydrate ────────────────────────────────────────────────────────────
+
+
+def _write_swap(path: Path, records: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return path
+
+
+def test_hydrate_summary_uses_renderer(tmp_path: Path):
+    swap = _write_swap(
+        tmp_path / "swap.jsonl",
+        [
+            {"identifier": "a", "fact_text": "fact one"},
+            {"identifier": "b", "fact_text": "fact two"},
+        ],
+    )
+    db_path = tmp_path / "db.sqlite"
+    runner = CliRunner()
+    result = runner.invoke(main, ["hydrate", "--file", str(swap), "--db", str(db_path)])
+    assert result.exit_code == 0, result.output
+    assert "hydrate" in result.output
+    assert "loaded=2" in result.output
+    assert "skipped_dupes=0" in result.output
+
+
+def test_hydrate_progress_runs_without_error_when_piped(tmp_path: Path):
+    # Piped (CliRunner) must not raise even though progress is a no-op.
+    swap = _write_swap(tmp_path / "s.jsonl", [{"identifier": "x", "fact_text": "y"}])
+    runner = CliRunner()
+    db_path = str(tmp_path / "d.sqlite")
+    result = runner.invoke(main, ["hydrate", "--file", str(swap), "--db", db_path])
+    assert result.exit_code == 0
+
+
+# ── snapshot ───────────────────────────────────────────────────────────
+
+
+def test_snapshot_summary_includes_path(tmp_path: Path):
+    db_path = tmp_path / "db.sqlite"
+    db = MemoryDB(db_path)
+    db.insert(
+        id="1",
+        identifier="a",
+        fact_text="snapshot me",
+        embedding=pack_embedding(embed_text("snapshot me")),
+        importance=0.5,
+    )
+    db.close()
+
+    out_path = tmp_path / "out.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(main, ["snapshot", "--file", str(out_path), "--db", str(db_path)])
+    assert result.exit_code == 0, result.output
+    assert "snapshot" in result.output
+    assert "exported=1" in result.output
+    assert str(out_path) in result.output
+    assert out_path.exists()
+
+
+# ── search ─────────────────────────────────────────────────────────────
+
+
+def _seed_db(db_path: Path):
+    db = MemoryDB(db_path)
+    for i, text in enumerate(["invoice validation required", "late payment risk", "generic note"]):
+        db.insert(
+            id=str(i),
+            identifier="test",
+            fact_text=text,
+            embedding=pack_embedding(embed_text(text)),
+            importance=0.5,
+        )
+    db.close()
+
+
+def test_search_db_backend_renders_results(tmp_path: Path):
+    db_path = tmp_path / "db.sqlite"
+    _seed_db(db_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["search", "invoice", "--db", str(db_path)])
+    assert result.exit_code == 0, result.output
+    # PlainRenderer emits numbered rows; the top hit is the invoice fact.
+    assert "1." in result.output
+    assert "invoice" in result.output
+
+
+def test_search_json_flag_bypasses_renderer(tmp_path: Path):
+    db_path = tmp_path / "db.sqlite"
+    _seed_db(db_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["search", "invoice", "--db", str(db_path), "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert isinstance(parsed, list)
+    assert all("content" in r for r in parsed)
+
+
+def test_search_requires_db_or_url():
+    runner = CliRunner()
+    result = runner.invoke(main, ["search", "anything"])
+    assert result.exit_code != 0
+    assert "requires" in result.output.lower() or "db" in result.output.lower()
+
+
+def test_search_url_backend(tmp_path: Path):
+    runner = CliRunner()
+    rows = [{"role": "system", "content": "hit", "identifier": "a", "score": 0.9}]
+    resp = mock.Mock()
+    resp.raise_for_status = mock.Mock()
+    resp.json = lambda: {"memories": rows}
+    with mock.patch("httpx.post", return_value=resp):
+        result = runner.invoke(main, ["search", "q", "--url", "http://127.0.0.1:8711"])
+    assert result.exit_code == 0, result.output
+    assert "hit" in result.output
+
+
+# ── renderer delegation sanity ──────────────────────────────────────────
+
+
+def test_cli_status_uses_renderer_directly(monkeypatch: pytest.MonkeyPatch):
+    """Ensure status() routes through ui.status rather than raw click.echo."""
+    called = {}
+
+    def fake_status(self, data):
+        called["data"] = data
+
+    monkeypatch.setattr(PlainRenderer, "status", fake_status)
+    with mock.patch("httpx.get") as g:
+        g.return_value = mock.Mock(json=lambda: {"status": "ok"})
+        res = CliRunner().invoke(main, ["status"])
+    assert res.exit_code == 0, res.output
+    assert called.get("data") == {"status": "ok"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,13 +161,21 @@ def test_search_requires_db_or_url():
 def test_search_url_backend(tmp_path: Path):
     runner = CliRunner()
     rows = [{"role": "system", "content": "hit", "identifier": "a", "score": 0.9}]
-    resp = mock.Mock()
-    resp.raise_for_status = mock.Mock()
-    resp.json = lambda: {"memories": rows}
-    with mock.patch("httpx.post", return_value=resp):
+    fake_client = mock.Mock()
+    fake_client.search = mock.Mock(return_value=rows)
+    with mock.patch("hotmem.client.HotMemClient", return_value=fake_client):
         result = runner.invoke(main, ["search", "q", "--url", "http://127.0.0.1:8711"])
     assert result.exit_code == 0, result.output
     assert "hit" in result.output
+
+
+def test_search_rejects_both_db_and_url(tmp_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["search", "q", "--db", str(tmp_path / "x.sqlite"), "--url", "http://127.0.0.1:8711"]
+    )
+    assert result.exit_code != 0
+    assert "not both" in result.output.lower()
 
 
 # ── renderer delegation sanity ──────────────────────────────────────────

--- a/tests/test_import_mem0.py
+++ b/tests/test_import_mem0.py
@@ -1,0 +1,294 @@
+"""Tests for hotmem.importers.mem0 — read mem0 SQLite history DB.
+
+Builds synthetic mem0-style SQLite DBs with the exact schema from
+mem0.SQLiteManager._create_history_table to validate field mapping, event
+filtering, streaming, and error handling — without depending on the mem0
+package itself.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from hotmem.cli import main
+from hotmem.importers import IMPORTERS
+from hotmem.importers.mem0 import read_mem0_sqlite
+
+_CREATE_HISTORY = """
+CREATE TABLE history (
+    id           TEXT PRIMARY KEY,
+    memory_id    TEXT,
+    old_memory   TEXT,
+    new_memory   TEXT,
+    event        TEXT,
+    created_at   TEXT,
+    updated_at   TEXT,
+    is_deleted   INTEGER,
+    actor_id     TEXT,
+    role         TEXT
+)
+"""
+
+
+def _make_mem0_db(path: Path, rows: list[tuple]) -> Path:
+    """Create a mem0-style history DB with the given rows.
+
+    rows: tuples of (id, memory_id, new_memory, event, is_deleted, actor_id, created_at)
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute(_CREATE_HISTORY)
+    for r in rows:
+        rid, memory_id, new_memory, event, is_deleted, actor_id, created_at = r
+        conn.execute(
+            "INSERT INTO history (id, memory_id, old_memory, new_memory, event, "
+            "created_at, updated_at, is_deleted, actor_id, role) "
+            "VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, NULL)",
+            (rid, memory_id, new_memory, event, created_at, created_at, is_deleted, actor_id),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+# ── read_mem0_sqlite unit tests ────────────────────────────────────────
+
+
+def test_registry_has_mem0():
+    assert "mem0" in IMPORTERS
+    assert IMPORTERS["mem0"] is read_mem0_sqlite
+
+
+def test_maps_fields_correctly(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "Prefers dark mode", "ADD", 0, "user-42", "2026-01-01T00:00:00Z"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    r = records[0]
+    assert r["fact_text"] == "Prefers dark mode"
+    assert r["identifier"] == "user-42"
+    assert r["created_at"] == "2026-01-01T00:00:00Z"
+    assert r["source"] == "mem0"
+    assert r["id"] == "h1"
+
+
+def test_skips_non_add_events(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "added fact", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m1", "updated fact", "UPDATE", 0, "u1", "2026-01-02"),
+            ("h3", "m1", None, "DELETE", 1, "u1", "2026-01-03"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    assert records[0]["fact_text"] == "added fact"
+
+
+def test_skips_deleted_rows(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "alive", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m2", "deleted", "ADD", 1, "u1", "2026-01-02"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    assert records[0]["fact_text"] == "alive"
+
+
+def test_skips_null_or_empty_memory(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "valid", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m2", None, "ADD", 0, "u1", "2026-01-02"),
+            ("h3", "m3", "", "ADD", 0, "u1", "2026-01-03"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    assert records[0]["fact_text"] == "valid"
+
+
+def test_null_actor_falls_back_to_mem0(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "no actor", "ADD", 0, None, "2026-01-01"),
+            ("h2", "m2", "empty actor", "ADD", 0, "", "2026-01-02"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert all(r["identifier"] == "mem0" for r in records)
+
+
+def test_returns_iterator_not_list(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [("h1", "m1", "fact", "ADD", 0, "u1", "2026-01-01")],
+    )
+    gen = read_mem0_sqlite(db)
+    assert isinstance(gen, Iterator)
+    first = next(gen)
+    assert first["fact_text"] == "fact"
+    with pytest.raises(StopIteration):
+        next(gen)
+
+
+def test_on_progress_callback_invoked_per_row(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "fact one", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m2", "fact two", "ADD", 0, "u1", "2026-01-02"),
+            ("h3", "m3", "fact three", "ADD", 0, "u1", "2026-01-03"),
+        ],
+    )
+    seen = []
+    list(read_mem0_sqlite(db, on_progress=seen.append))
+    assert seen == [1, 2, 3]
+
+
+def test_rejects_missing_history_table(tmp_path: Path):
+    db = tmp_path / "not_mem0.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE unrelated (id TEXT)")
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValueError, match="no 'history' table"):
+        list(read_mem0_sqlite(db))
+
+
+def test_rejects_wrong_schema(tmp_path: Path):
+    db = tmp_path / "wrong_schema.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE history (id TEXT, foo TEXT)")
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValueError, match="missing expected mem0 columns"):
+        list(read_mem0_sqlite(db))
+
+
+def test_rejects_non_sqlite_file(tmp_path: Path):
+    bad = tmp_path / "not_a_db"
+    bad.write_text("not sqlite")
+    with pytest.raises(ValueError, match="not a SQLite database"):
+        list(read_mem0_sqlite(bad))
+
+
+def test_missing_file_raises_filenotfound(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        list(read_mem0_sqlite(tmp_path / "ghost.db"))
+
+
+def test_empty_db_yields_nothing(tmp_path: Path):
+    db = _make_mem0_db(tmp_path / "empty.db", [])
+    records = list(read_mem0_sqlite(db))
+    assert records == []
+
+
+# ── CLI end-to-end ────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _force_plain(monkeypatch: pytest.MonkeyPatch):
+    import hotmem.ui as ui
+
+    monkeypatch.setattr(ui, "_use_rich", lambda: False)
+
+
+def test_cli_import_mem0_round_trip(tmp_path: Path):
+    source = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "invoice total 5000", "ADD", 0, "vendor_a", "2026-01-01"),
+            ("h2", "m2", "late payment risk", "ADD", 0, "vendor_b", "2026-01-02"),
+            ("h3", "m3", "stale note", "ADD", 1, "vendor_c", "2026-01-03"),
+        ],
+    )
+    target = tmp_path / "hotmem.sqlite"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["import", "--from", "mem0", "--db", str(source), "--target", str(target)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "import" in result.output
+    assert "imported=2" in result.output
+    assert "source=mem0" in result.output
+    assert str(target) in result.output
+
+    # Verify the memories landed and are searchable in HotMem.
+    from hotmem.db import MemoryDB
+
+    db = MemoryDB(str(target))
+    assert db.count() == 2
+    db.close()
+
+
+def test_cli_import_out_retains_swap_file(tmp_path: Path):
+    source = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [("h1", "m1", "keep this", "ADD", 0, "u1", "2026-01-01")],
+    )
+    out = tmp_path / "export.jsonl"
+    target = tmp_path / "t.sqlite"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "import",
+            "--from",
+            "mem0",
+            "--db",
+            str(source),
+            "--target",
+            str(target),
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    import json
+
+    lines = out.read_text().strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["fact_text"] == "keep this"
+    assert rec["source"] == "mem0"
+
+
+def test_cli_import_rejects_missing_source(tmp_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["import", "--from", "mem0", "--db", str(tmp_path / "ghost.db")],
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_import_rejects_non_mem0_db(tmp_path: Path):
+    bad = tmp_path / "bad.db"
+    conn = sqlite3.connect(str(bad))
+    conn.execute("CREATE TABLE x (id TEXT)")
+    conn.commit()
+    conn.close()
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["import", "--from", "mem0", "--db", str(bad), "--target", str(tmp_path / "t.sqlite")],
+    )
+    assert result.exit_code != 0
+    assert "history" in result.output or "mem0" in result.output.lower()

--- a/tests/test_import_mem0.py
+++ b/tests/test_import_mem0.py
@@ -1,8 +1,8 @@
-"""Tests for hotmem.importers.mem0 — read mem0 SQLite history DB.
+"""Tests for hotmem.importers.mem0 — read mem0 SQLite history DB (replay semantics).
 
 Builds synthetic mem0-style SQLite DBs with the exact schema from
-mem0.SQLiteManager._create_history_table to validate field mapping, event
-filtering, streaming, and error handling — without depending on the mem0
+mem0.SQLiteManager._create_history_table to validate event replay, field
+mapping, streaming, and error handling — without depending on the mem0
 package itself.
 """
 
@@ -36,9 +36,10 @@ CREATE TABLE history (
 
 
 def _make_mem0_db(path: Path, rows: list[tuple]) -> Path:
-    """Create a mem0-style history DB with the given rows.
+    """Create a mem0-style history DB.
 
-    rows: tuples of (id, memory_id, new_memory, event, is_deleted, actor_id, created_at)
+    rows: tuples of
+        (id, memory_id, new_memory, event, is_deleted, actor_id, created_at)
     """
     conn = sqlite3.connect(str(path))
     conn.execute(_CREATE_HISTORY)
@@ -55,12 +56,84 @@ def _make_mem0_db(path: Path, rows: list[tuple]) -> Path:
     return path
 
 
-# ── read_mem0_sqlite unit tests ────────────────────────────────────────
+# ── registry ──────────────────────────────────────────────────────────
 
 
 def test_registry_has_mem0():
     assert "mem0" in IMPORTERS
     assert IMPORTERS["mem0"] is read_mem0_sqlite
+
+
+# ── replay semantics (the core correctness contract) ──────────────────
+
+
+def test_replays_update_to_current_text(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "v1 original", "ADD", 0, "user-1", "2026-01-01"),
+            ("h2", "m1", "v2 updated", "UPDATE", 0, "user-1", "2026-01-02"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    assert records[0]["fact_text"] == "v2 updated"
+    assert records[0]["created_at"] == "2026-01-02"
+
+
+def test_delete_after_add_removes_memory(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "alive", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m1", None, "DELETE", 1, "u1", "2026-01-02"),
+        ],
+    )
+    assert list(read_mem0_sqlite(db)) == []
+
+
+def test_update_then_delete_removes_memory(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "v1", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m1", "v2", "UPDATE", 0, "u1", "2026-01-02"),
+            ("h3", "m1", None, "DELETE", 1, "u1", "2026-01-03"),
+        ],
+    )
+    assert list(read_mem0_sqlite(db)) == []
+
+
+def test_is_deleted_row_marks_memory_dead_even_without_delete_event(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "alive", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m2", "gone", "ADD", 1, "u1", "2026-01-02"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    assert records[0]["fact_text"] == "alive"
+
+
+def test_multiple_memories_replay_independently(tmp_path: Path):
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "m1 v1", "ADD", 0, "a", "2026-01-01"),
+            ("h2", "m2", "m2 v1", "ADD", 0, "b", "2026-01-01"),
+            ("h3", "m1", "m1 v2", "UPDATE", 0, "a", "2026-01-02"),
+            ("h4", "m2", None, "DELETE", 1, "b", "2026-01-03"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    assert records[0]["fact_text"] == "m1 v2"
+    assert records[0]["identifier"] == "a"
+
+
+# ── field mapping ─────────────────────────────────────────────────────
 
 
 def test_maps_fields_correctly(tmp_path: Path):
@@ -77,48 +150,20 @@ def test_maps_fields_correctly(tmp_path: Path):
     assert r["identifier"] == "user-42"
     assert r["created_at"] == "2026-01-01T00:00:00Z"
     assert r["source"] == "mem0"
-    assert r["id"] == "h1"
 
 
-def test_skips_non_add_events(tmp_path: Path):
+def test_no_foreign_id_in_record(tmp_path: Path):
+    """HotMem memory ids are NOT carried from mem0 — hydrate generates them.
+
+    Carrying mem0's history row id would let a PK collision silently drop
+    memories (INSERT OR IGNORE); content_hash dedup gives idempotent re-import.
+    """
     db = _make_mem0_db(
         tmp_path / "mem0.db",
-        [
-            ("h1", "m1", "added fact", "ADD", 0, "u1", "2026-01-01"),
-            ("h2", "m1", "updated fact", "UPDATE", 0, "u1", "2026-01-02"),
-            ("h3", "m1", None, "DELETE", 1, "u1", "2026-01-03"),
-        ],
+        [("h1", "m1", "fact", "ADD", 0, "u1", "2026-01-01")],
     )
-    records = list(read_mem0_sqlite(db))
-    assert len(records) == 1
-    assert records[0]["fact_text"] == "added fact"
-
-
-def test_skips_deleted_rows(tmp_path: Path):
-    db = _make_mem0_db(
-        tmp_path / "mem0.db",
-        [
-            ("h1", "m1", "alive", "ADD", 0, "u1", "2026-01-01"),
-            ("h2", "m2", "deleted", "ADD", 1, "u1", "2026-01-02"),
-        ],
-    )
-    records = list(read_mem0_sqlite(db))
-    assert len(records) == 1
-    assert records[0]["fact_text"] == "alive"
-
-
-def test_skips_null_or_empty_memory(tmp_path: Path):
-    db = _make_mem0_db(
-        tmp_path / "mem0.db",
-        [
-            ("h1", "m1", "valid", "ADD", 0, "u1", "2026-01-01"),
-            ("h2", "m2", None, "ADD", 0, "u1", "2026-01-02"),
-            ("h3", "m3", "", "ADD", 0, "u1", "2026-01-03"),
-        ],
-    )
-    records = list(read_mem0_sqlite(db))
-    assert len(records) == 1
-    assert records[0]["fact_text"] == "valid"
+    r = list(read_mem0_sqlite(db))[0]
+    assert "id" not in r
 
 
 def test_null_actor_falls_back_to_mem0(tmp_path: Path):
@@ -131,6 +176,23 @@ def test_null_actor_falls_back_to_mem0(tmp_path: Path):
     )
     records = list(read_mem0_sqlite(db))
     assert all(r["identifier"] == "mem0" for r in records)
+
+
+def test_update_with_null_new_memory_keeps_prior_text(tmp_path: Path):
+    # An UPDATE row whose new_memory is NULL should not blank the memory.
+    db = _make_mem0_db(
+        tmp_path / "mem0.db",
+        [
+            ("h1", "m1", "real text", "ADD", 0, "u1", "2026-01-01"),
+            ("h2", "m1", None, "UPDATE", 0, "u1", "2026-01-02"),
+        ],
+    )
+    records = list(read_mem0_sqlite(db))
+    assert len(records) == 1
+    assert records[0]["fact_text"] == "real text"
+
+
+# ── streaming / progress ──────────────────────────────────────────────
 
 
 def test_returns_iterator_not_list(tmp_path: Path):
@@ -146,7 +208,7 @@ def test_returns_iterator_not_list(tmp_path: Path):
         next(gen)
 
 
-def test_on_progress_callback_invoked_per_row(tmp_path: Path):
+def test_on_progress_callback_invoked_per_emitted_record(tmp_path: Path):
     db = _make_mem0_db(
         tmp_path / "mem0.db",
         [
@@ -158,6 +220,9 @@ def test_on_progress_callback_invoked_per_row(tmp_path: Path):
     seen = []
     list(read_mem0_sqlite(db, on_progress=seen.append))
     assert seen == [1, 2, 3]
+
+
+# ── error handling ────────────────────────────────────────────────────
 
 
 def test_rejects_missing_history_table(tmp_path: Path):
@@ -194,8 +259,7 @@ def test_missing_file_raises_filenotfound(tmp_path: Path):
 
 def test_empty_db_yields_nothing(tmp_path: Path):
     db = _make_mem0_db(tmp_path / "empty.db", [])
-    records = list(read_mem0_sqlite(db))
-    assert records == []
+    assert list(read_mem0_sqlite(db)) == []
 
 
 # ── CLI end-to-end ────────────────────────────────────────────────────
@@ -215,6 +279,7 @@ def test_cli_import_mem0_round_trip(tmp_path: Path):
             ("h1", "m1", "invoice total 5000", "ADD", 0, "vendor_a", "2026-01-01"),
             ("h2", "m2", "late payment risk", "ADD", 0, "vendor_b", "2026-01-02"),
             ("h3", "m3", "stale note", "ADD", 1, "vendor_c", "2026-01-03"),
+            ("h4", "m1", "invoice total 6000", "UPDATE", 0, "vendor_a", "2026-01-04"),
         ],
     )
     target = tmp_path / "hotmem.sqlite"
@@ -225,11 +290,11 @@ def test_cli_import_mem0_round_trip(tmp_path: Path):
     )
     assert result.exit_code == 0, result.output
     assert "import" in result.output
+    # m1 → updated to "invoice total 6000", m2 → "late payment risk", m3 → deleted
     assert "imported=2" in result.output
     assert "source=mem0" in result.output
     assert str(target) in result.output
 
-    # Verify the memories landed and are searchable in HotMem.
     from hotmem.db import MemoryDB
 
     db = MemoryDB(str(target))
@@ -268,6 +333,7 @@ def test_cli_import_out_retains_swap_file(tmp_path: Path):
     rec = json.loads(lines[0])
     assert rec["fact_text"] == "keep this"
     assert rec["source"] == "mem0"
+    assert "id" not in rec
 
 
 def test_cli_import_rejects_missing_source(tmp_path: Path):

--- a/tests/test_swap.py
+++ b/tests/test_swap.py
@@ -11,7 +11,7 @@ import pytest
 
 from hotmem.db import MemoryDB
 from hotmem.embed import EMBEDDING_MODEL, embed_text, pack_embedding
-from hotmem.swap import compute_content_hash, hydrate, snapshot
+from hotmem.swap import add_memory, compute_content_hash, hydrate, snapshot
 
 
 def test_compute_content_hash():
@@ -20,6 +20,38 @@ def test_compute_content_hash():
     h3 = compute_content_hash("id1", "fact2")
     assert h1 == h2
     assert h1 != h3
+
+
+def test_add_memory_canonical_contract(tmp_db: MemoryDB):
+    """add_memory emits the full canonical contract (embedding_model, source, metadata)."""
+    memory_id, content_hash = add_memory(
+        tmp_db,
+        "vendor_a",
+        "Invoice total $5000",
+        source="test",
+        importance=0.8,
+        metadata={"doc": "inv-1"},
+    )
+    assert memory_id and content_hash
+    assert tmp_db.count() == 1
+    rows = tmp_db.all_rows()
+    row = rows[0]
+    assert row["identifier"] == "vendor_a"
+    assert row["source"] == "test"
+    assert row["importance"] == 0.8
+    assert row["content_hash"] == content_hash
+    assert json.loads(row["metadata_json"]) == {"doc": "inv-1"}
+    # Canonical fields the FastAPI example previously omitted:
+    assert row["embedding_model"] == EMBEDDING_MODEL
+    assert row["embedding_dim"] is not None
+
+
+def test_add_memory_defaults(tmp_db: MemoryDB):
+    """add_memory with defaults still stamps source/metadata (no NULL drift)."""
+    mid, _ = add_memory(tmp_db, "x", "fact")
+    row = tmp_db.all_rows()[0]
+    assert row["source"] == ""
+    assert json.loads(row["metadata_json"]) == {}
 
 
 def test_hydrate_from_swap(tmp_db: MemoryDB, tmp_path: Path):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,118 @@
+"""Tests for hotmem.ui — renderer factory + Plain/Rich behaviour."""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+import hotmem.ui as ui
+
+
+@pytest.fixture
+def force_plain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the PlainRenderer for tests that need deterministic output."""
+    monkeypatch.setattr(ui, "_use_rich", lambda: False)
+
+
+def test_factory_returns_plain_when_not_tty(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ui.sys, "stdout", mock.Mock(isatty=lambda: False))
+    r = ui.get_renderer()
+    assert isinstance(r, ui.PlainRenderer)
+
+
+def test_factory_returns_plain_when_no_color(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ui.sys, "stdout", mock.Mock(isatty=lambda: True))
+    monkeypatch.setattr(os, "environ", {"NO_COLOR": "1"})
+    r = ui.get_renderer()
+    assert isinstance(r, ui.PlainRenderer)
+
+
+def test_factory_returns_plain_when_term_dumb(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ui.sys, "stdout", mock.Mock(isatty=lambda: True))
+    monkeypatch.setattr(os, "environ", {"TERM": "dumb"})
+    r = ui.get_renderer()
+    assert isinstance(r, ui.PlainRenderer)
+
+
+def test_factory_returns_plain_when_rich_missing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ui.sys, "stdout", mock.Mock(isatty=lambda: True))
+    monkeypatch.setattr(os, "environ", {})
+    monkeypatch.setattr(ui, "_rich_available", lambda: False)
+    r = ui.get_renderer()
+    assert isinstance(r, ui.PlainRenderer)
+
+
+def test_plain_status_emits_all_keys(capsys: pytest.CaptureFixture[str], force_plain):
+    ui.get_renderer().status(
+        {"status": "ok", "memory_count": 7, "db_path": "/tmp/x.sqlite", "uptime_s": 12.3}
+    )
+    out = capsys.readouterr().out
+    assert "Status" in out
+    assert "ok" in out
+    assert "Memory Count" in out
+    assert "7" in out
+    assert "/tmp/x.sqlite" in out
+    assert "12.3" in out
+
+
+def test_plain_status_skips_missing_keys(capsys: pytest.CaptureFixture[str], force_plain):
+    ui.get_renderer().status({"status": "ok"})
+    out = capsys.readouterr().out
+    assert "Status" in out
+    assert "Memory Count" not in out
+
+
+def test_plain_search_results_numbered(capsys: pytest.CaptureFixture[str], force_plain):
+    rows = [
+        {"score": 0.9, "identifier": "a", "content": "fact one"},
+        {"score": 0.5, "identifier": "b", "content": "fact two"},
+    ]
+    ui.get_renderer().search_results(rows)
+    out = capsys.readouterr().out
+    assert "1." in out and "0.9" in out and "fact one" in out
+    assert "2." in out and "fact two" in out
+
+
+def test_plain_search_results_empty(capsys: pytest.CaptureFixture[str], force_plain):
+    ui.get_renderer().search_results([])
+    out = capsys.readouterr().out
+    assert "No memories" in out
+
+
+def test_plain_summary(capsys: pytest.CaptureFixture[str], force_plain):
+    ui.get_renderer().summary("hydrate", loaded=3, skipped_dupes=1)
+    out = capsys.readouterr().out
+    assert "hydrate" in out and "loaded=3" in out and "skipped_dupes=1" in out
+
+
+def test_plain_progress_silent(capsys: pytest.CaptureFixture[str], force_plain):
+    with ui.get_renderer().progress(total=100, desc="x") as tick:
+        for _ in range(100):
+            tick(1)
+    out = capsys.readouterr().out
+    assert out == ""
+
+
+def test_rich_renderer_status_outputs_to_console(monkeypatch: pytest.MonkeyPatch):
+    # RichRenderer is exercised in CI via the dev extra; skip if not installed.
+    pytest.importorskip("rich")
+    r = ui.RichRenderer()
+    # Should not raise; output goes to the rich console (captured by capsys-ish).
+    r.status({"status": "ok", "memory_count": 1, "db_path": "p", "uptime_s": 0.1})
+
+
+def test_rich_renderer_search_results(monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip("rich")
+    r = ui.RichRenderer()
+    r.search_results([{"score": 0.9, "identifier": "a", "content": "x"}])
+    r.search_results([])
+
+
+def test_rich_progress_contextmanager():
+    pytest.importorskip("rich")
+    r = ui.RichRenderer()
+    with r.progress(total=10, desc="test") as tick:
+        for _ in range(10):
+            tick(1)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -116,3 +116,11 @@ def test_rich_progress_contextmanager():
     with r.progress(total=10, desc="test") as tick:
         for _ in range(10):
             tick(1)
+
+
+def test_rich_progress_indeterminate_total_none():
+    pytest.importorskip("rich")
+    r = ui.RichRenderer()
+    with r.progress(total=None, desc="reading") as tick:
+        tick(1)
+        tick(1)

--- a/uv.lock
+++ b/uv.lock
@@ -465,6 +465,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "rich" },
     { name = "ruff" },
 ]
 docs = [
@@ -476,6 +477,9 @@ mcp = [
     { name = "mcp" },
 ]
 playground = [
+    { name = "rich" },
+]
+rich = [
     { name = "rich" },
 ]
 
@@ -490,11 +494,13 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9,<10" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6,<7" },
     { name = "pyyaml", marker = "extra == 'docs'", specifier = ">=6.0,<7" },
+    { name = "rich", marker = "extra == 'dev'", specifier = ">=13.7,<14" },
     { name = "rich", marker = "extra == 'playground'", specifier = ">=13.7,<14" },
+    { name = "rich", marker = "extra == 'rich'", specifier = ">=13.7,<14" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15,<1" },
     { name = "uvicorn", specifier = ">=0.30,<1" },
 ]
-provides-extras = ["mcp", "playground", "docs", "dev"]
+provides-extras = ["mcp", "playground", "rich", "docs", "dev"]
 
 [[package]]
 name = "httpcore"

--- a/uv.lock
+++ b/uv.lock
@@ -452,7 +452,7 @@ wheels = [
 
 [[package]]
 name = "hotmem"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Phase 4: Adoption Accelerators (#15, #16, #17)

All three Phase-4 adoption tickets, landed one at a time as separate commits on this branch.

### Progress
- [x] **#16 — Rich CLI output** (landed)
- [x] **#15 — mem0 import tool** (landed)
- [x] **#17 — Examples repository** (landed)

---

### #16 — Rich CLI output (done)

**Rendering seam + optional rich, zero dep creep into core.**

- `src/hotmem/ui.py` — `Renderer` protocol with `PlainRenderer` (click.echo, silent progress when piped) and `RichRenderer` (lazy rich import, colored panels/tables, byte- and row-based progress bars; indeterminate spinner when `total=None`). Factory gates on TTY, `NO_COLOR`, `TERM=dumb`, and rich availability — so `import hotmem.cli` stays dep-free and piped output stays clean. Hoisted `_STATUS_KEYS` so both renderers share the health-payload contract.
- `src/hotmem/swap.py` — optional `on_progress` callbacks on `hydrate` (byte-based) and `snapshot` (count-based); pure, default `None` preserves existing behavior/tests. Added `write_record(f, record)` helper so snapshot + import share one serialization contract.
- `src/hotmem/cli.py` — `status`/`hydrate`/`snapshot` route through `ui`; **new** `hotmem search QUERY [--db|--url] [--top-k] [--json]` exposes the ranked search surface with score-formatted output (`--json` bypasses the renderer for scripting); rejects `--db` + `--url` together.
- `pyproject.toml` — new `[rich]` optional extra; `rich` bundled into `[dev]` so CI exercises both renderers without workflow edits. Base deps + Docker image unchanged (≤100MB #12 constraint respected).
- Tests: `tests/test_ui.py` (factory selection + renderer shapes + indeterminate progress), `tests/test_cli.py` (CliRunner coverage for status up/down, hydrate, snapshot, search db/url/json/both-rejected — renderer-agnostic assertions, `NO_COLOR`-forced deterministic).

**Acceptance criteria**
- [x] `hotmem status` output is formatted and colored (RichRenderer) with plain fallback
- [x] Large hydrate/snapshot operations show progress (byte-based hydrate, count-based snapshot)
- [x] Plain text fallback when rich is not installed or output is piped (factory gate + silent `PlainRenderer.progress`)

Closes #16.

---

### #15 — mem0 import tool (done)

**Read mem0's canonical SQLite history DB → HotMem swap JSONL → hydrate, one command. Replays the audit log for current state.**

- `src/hotmem/importers/__init__.py` — pluggable importer registry (`IMPORTERS` dict + `register()` extension point); `mem0` registered by default.
- `src/hotmem/importers/mem0.py` — `read_mem0_sqlite(path, on_progress)` replays mem0's `history` audit log per `memory_id` in created_at order (ADD/UPDATE set current text, DELETE/`is_deleted` mark dead) and emits one record per live memory_id with its **current** text — not the stale ADD-only text. Targets the always-present `history` table rather than the vector store, so no Qdrant/Chroma client deps; embeddings are re-computed by HotMem's embedder (dims differ, reuse impossible). HotMem memory ids are NOT carried from mem0 (hydrate auto-generates uuid4 + content_hash dedup → idempotent re-import, no foreign-PK silent drops). Schema validation with clear errors for non-mem0 DBs.
- `src/hotmem/cli.py` — `hotmem import --from mem0 --db SOURCE --target DB [--out swap.jsonl]`. Uses `mkdtemp`-scoped paths (atomic, closes the `mktemp` TOCTOU race); default temp swap + target DB cleaned up in `finally` (no on-disk leak, including error path). Reading phase uses indeterminate progress (`total=None`); hydrate phase uses byte-total. `--out` retains the JSONL; `ValueError`/`FileNotFoundError` surfaced as `ClickException`.
- Tests: `tests/test_import_mem0.py` — synthetic mem0-schema DBs for replay semantics (UPDATE→current, DELETE removal, `is_deleted`, independent replay, no foreign id, null-new-memory keeps prior text), field mapping, streaming, `on_progress`, schema rejection (missing table / wrong cols / non-sqlite / missing file), and CliRunner end-to-end round-trip (import → searchable HotMem DB) + `--out` retention + error paths.

**Acceptance criteria**
- [x] Reads mem0 exported data and converts to HotMem format (history SQLite → swap JSONL → HotMem DB, current state)
- [x] One-command migration path (`hotmem import --from mem0 --db ... --target ...`)

Closes #15.

---

### #17 — Examples repository (done)

**In-repo `examples/` (over a separate repo) so examples track main with no cross-repo drift and reuse the existing ruff CI.**

- `examples/README.md` — index table + per-example run commands + prereqs.
- `examples/langchain_agent/agent.py` — `HotMemRetriever` + LLM agent loop (falls back to `FakeListChatModel` stub when no `OPENAI_API_KEY` so it runs without a key).
- `examples/crewai_crew/crew.py` — shared HotMem across a Researcher + Writer crew.
- `examples/autogen_group_chat/chat.py` — `HotMemMemoryPlugin` recall/persist in a group chat.
- `examples/pydanticai_agent/agent.py` — `HotMemDeps` + `recall_system_prompt` + `remember` tool.
- `examples/fastapi_backend/app.py` — standalone FastAPI app using HotMem **as an in-process library** (`MemoryDB` + `search_memories`), no sidecar. `requirements.txt` pins deps. Smoke-verified: `/remember` → `/ask` round-trips, `/health` reports count.
- `examples/mcp_claude_desktop/` — `claude_desktop_config.json` snippet + walkthrough for wiring `hotmem mcp` into Claude Desktop.
- `examples/typescript/agent.ts` — `HotMemClient` add/search/health against `hotmem serve`.
- CI: extended `ruff check` + `ruff format --check` to `examples/` (lints syntax/import-order without installing framework deps — ruff doesn't execute imports).

**Acceptance criteria**
- [x] Each example runs with a README and minimal setup
- [x] Examples cover Python and TypeScript where applicable (5 Python + 1 TS + 1 MCP config)

Closes #17.

---

### Version
Bumped to `0.1.9` (synced in `pyproject.toml` + `src/hotmem/__init__.py`); on merge to main `auto-tag.yml` creates the `v0.1.9` tag and triggers `release.yml` to build/verify/publish to PyPI + GitHub Release.

### Verification (all commits)
- `uv run ruff check src/ tests/ examples/` — clean
- `uv run ruff format --check src/ tests/ examples/` — clean
- `uv run pytest` — 147 passed
- Manual smoke: `hotmem status` (up + down), `hotmem search` (db + url + json), `hotmem import --from mem0` (replay UPDATE/DELETE semantics verified), FastAPI example end-to-end.
