### PR TITLE
#53 #54 File inspectors + compatibility golden tests (file-native vNext foundation)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,193 @@
+# Plan: File Inspectors (#53) + Compatibility Golden Tests (#54)
+
+Branch: `feat/file-inspectors-golden-tests-53-54` (off `main` @ 0f0b8da)
+Milestone target: M1 (#54, P0) + M5 (#53, P1/P2). Recommended order in
+`docs/okf/file-native-memory-practices.md` §13 is: golden tests first, then
+inspectors — so #54 lands first to lock the contract, then #53 adds behind it.
+
+## 0. Design philosophy (the 10x posture)
+
+- **Compatibility is the product.** Every new line is additive. The non-breaking
+  contract from `file-aware-architecture.md` §5 must become *executable*, not
+  aspirational — that is the entire point of #54.
+- **Filesystem first, never a query engine.** #53 inspects *about* files, not
+  *into* them analytically. No DuckDB/Polars/Arrow runtime dependency. Parquet
+  support is **metadata-only via a dependency-free Thrift Compact footer
+  reader** — this is the disruptive-in-scope bet: production-grade Parquet
+  provenance with **zero** new deps, staying inside the "HotMem owns vs EMOS
+  owns" boundary (`file-aware-architecture.md` §4).
+- **Provenance over copy.** Inspectors never pull large file contents into
+  SQLite. They return URI + size + checksum + byte ranges + light summary so
+  memories can *reference* data (#38 enabler) without inflating the hot store.
+- **Streaming + seek, no full loads.** CSV uses the stdlib `csv` reader with a
+  bounded sniff; JSONL counts newlines via a buffered byte scan and samples by
+  `seek`; Parquet reads only the footer tail. Memory footprint is O(1) for the
+  metadata path regardless of file size — this is what makes it safe on
+  production workloads.
+- **Fail loudly, fail structured.** Unsupported formats raise
+  `UnsupportedFormatError` with an actionable message, mirroring the existing
+  `UnsupportedSchemeError` in `storage/__init__.py`.
+- **Local-only surface, for now.** Inspectors ship as a Python API + a
+  `hotmem inspect` CLI subcommand. No `/v1` or MCP endpoints — those belong to
+  #43 (API extensions) and would widen the compatibility surface #54 is locking.
+
+## 1. Issue #54 — Compatibility golden tests (lands first)
+
+Goal: make the non-breaking contract executable *before* more vNext code lands.
+
+### Layout
+```
+tests/golden/
+  __init__.py
+  conftest.py            # shared golden fixtures (stable server + deterministic clock)
+  fixtures/
+    add_minimal.jsonl        # canonical {identifier, fact} add payload
+    add_extended.jsonl       # {identifier, fact, source, importance, metadata, ttl_seconds}
+    search_expected.json     # locked /v1/search message-object shape
+    memories_expected.json   # locked /v1/memories row shape
+  test_golden_api.py
+  test_golden_swap.py
+  test_golden_client.py
+  test_golden_mcp.py
+  test_golden_additive.py
+```
+
+### What gets locked
+1. **API shapes** (`test_golden_api.py`): exact top-level key sets and value
+   *types* for `/v1/health`, `/v1/add`, `/v1/search`, `/v1/memories`,
+   `/v1/hydrate`, `/v1/snapshot`. Volatile fields (`memory_id`, `content_hash`,
+   `created_at`, `trace_ms`, `uptime_s`, `db_path`) are masked to a stable
+   sentinel so snapshots are deterministic. Search message-object shape
+   (`role`/`content`/`memory_id`/`identifier`/`score`/`created_at`) is locked
+   against `fixtures/search_expected.json`.
+2. **Swap round trips** (`test_golden_swap.py`): JSONL and JSONL.GZ
+   snapshot→hydrate→snapshot are byte-shape stable (key set + ordering of the
+   first record), and a v0.1-style minimal record hydrates identically to a
+   v2-extended record. Locks the existing compatibility promise in
+   `file-native-memory-practices.md` §10.
+3. **Python client** (`test_golden_client.py`): `HotMemClient` and
+   `AsyncHotMemClient` method names, request payloads (vs a `MockTransport`),
+   and return shapes are locked. This is the surface `test_client.py` already
+   exercises informally — golden tests make it a *contract*.
+4. **MCP** (`test_golden_mcp.py`): tool-name set is an exact frozen set;
+   each tool's `inputSchema` top-level keys and `required` arrays are locked.
+   Backed by `test_mcp.py`'s existing wiring but asserting schema stability
+   specifically (the part that breaks clients when it drifts).
+5. **Additive proof** (`test_golden_additive.py`): a `POST /v1/add` with *only*
+   the legacy `{identifier, fact}` payload produces a memory whose
+   `/v1/search` and `/v1/memories` shapes are *identical* to one created with
+   the full extended payload minus the new fields. This is the executable
+   form of "new optional fields do not change default behavior" (#54 scope).
+
+### Determinism strategy
+- Use `TestClient` against a temp DB (existing pattern).
+- Mask volatile keys into typed sentinels (`"<uuid>"`, `"<hash>"`,
+  `"<ts>"`, `"<float>"`) before comparing, so snapshots are stable across
+  runs but still type-locked.
+
+## 2. Issue #53 — Lightweight file inspectors
+
+### Layout
+```
+src/hotmem/inspectors/
+  __init__.py            # registry: get_inspector(uri), UnsupportedFormatError, inspect_file()
+  base.py                # FileInspector Protocol, FileInspection dataclass
+  csv_inspector.py
+  jsonl_inspector.py
+  _thrift.py             # minimal Thrift Compact Protocol reader (production)
+  parquet_inspector.py   # footer-only metadata reader, no data-page decode
+```
+
+### `FileInspection` contract (`base.py`)
+A frozen dataclass that pairs storage provenance with format-specific metadata,
+designed so a future #38 file-backed memory can store it directly:
+
+```python
+@dataclass(frozen=True)
+class FileInspection:
+    uri: str
+    format: str                       # csv | jsonl | parquet | ...
+    size: int
+    mtime: float
+    checksum: str                     # sha256 from the storage adapter
+    columns: list[str] | None         # CSV headers / Parquet schema names
+    row_count: int | None             # None when not cheap to compute
+    delimiter: str | None              # CSV only
+    has_header: bool | None            # CSV only
+    num_row_groups: int | None         # Parquet only
+    schema_types: list[str] | None     # Parquet column types
+    sample: list[dict] | None          # bounded JSONL/CSV preview
+    byte_ranges: list[tuple[int, int]] | None  # provenance offsets for sample
+    metadata: dict[str, Any]          # format-specific extras
+    unsupported_reason: str | None    # set when format is recognized but limited
+```
+
+### Inspectors
+- **CSV** (`csv_inspector.py`): `csv.Sniffer` over a bounded head buffer for
+  delimiter + header detection; columns from the header row; `row_count`
+  computed only when `count_rows=True` via a streaming `\n` scan (cheap,
+  optional — matches issue's "optional row count when cheap"). Never loads the
+  whole file into memory. Sample = first N rows via the reader.
+- **JSONL** (`jsonl_inspector.py`): line count via buffered newline scan (O(file
+  size) byte read, O(1) memory). Range sampling via `seek(offset)` +
+  `readline()` to fetch selected records without parsing the whole file.
+  Validates each sampled line is JSON; reports first malformed line offset in
+  `unsupported_reason` rather than crashing.
+- **Parquet** (`parquet_inspector.py` + `_thrift.py`): validate `PAR1` magic
+  at head and tail; read last 8 bytes → footer length (LE uint32); read footer;
+  parse Thrift Compact `FileMetaData` → `version`, `num_rows`, `schema`
+  (column names + converted_type/physical type), `row_groups` count. **No data
+  page decoding, no query engine.** If `pyarrow` is installed at runtime it is
+  *not* used (deterministic, zero-dep path is the contract). Malformed/legacy
+  footers set `unsupported_reason` instead of raising, so a bad file becomes
+  provenance, not an outage.
+
+### Registry (`__init__.py`)
+```python
+def get_inspector(uri: str) -> FileInspector: ...   # by format from storage.metadata()
+def inspect_file(uri: str, *, count_rows=False, sample_size=5) -> FileInspection: ...
+```
+Unsupported formats → `UnsupportedFormatError` (mirrors `storage`'s
+`UnsupportedSchemeError`). Scheme resolution reuses `storage.get_adapter` so
+remote schemes fail fast with the existing EMOS-boundary error.
+
+### CLI
+`hotmem inspect <uri> [--count-rows] [--sample N] [--json]` — additive, uses
+`get_renderer()` for human output and `--json` for scripting (matches the
+`search` command's `--json` convention in `cli.py`).
+
+### Tests (`tests/test_inspectors.py`)
+- Fixtures generated in `tmp_path` (deterministic, no committed binaries):
+  - CSV with header + 3 rows, comma and `;` delimiters.
+  - JSONL with 5 records incl. one malformed line.
+  - Parquet via a small Thrift-Compact footer encoder in
+    `tests/_parquet_fixtures.py` producing a valid footer (num_rows, schema,
+    1 row group) — exercises the real parser on a real footer shape.
+- Assertions: stable metadata, no full-file copy into any DB, malformed JSONL
+  reported not raised, unsupported format raises `UnsupportedFormatError`,
+  Parquet returns metadata-only (no row data), existing hydrate/search tests
+  unchanged.
+
+## 3. Production hardening notes
+
+- All inspectors are read-only and side-effect free; safe to call concurrently.
+- Parquet footer read is bounded (footer length capped at a sane max to reject
+  hostile files: `len(file) - 8` sanity-checked).
+- `lru_cache` on checksum is already provided by the storage adapter; the
+  inspector reuses `storage.get_adapter(...).checksum(uri)` rather than
+  re-hashing.
+- No new runtime dependencies; `[dev]` unchanged. CI matrix (py3.11–3.14)
+  unaffected — pure stdlib.
+- Ruff: `target-version = "py311"`, line-length 100, existing rule set
+  (`E,F,I,UP,B,SIM`). All new code conforms.
+
+## 4. Out of scope (deferred to owning issues)
+- HTTP/MCP endpoints for inspection → #43.
+- File-backed memory hydration from inspection → #38.
+- Bundle readers, directory snapshots, event log, promotion → #39–#42.
+- Parquet data-page decoding, partitioning, query → EMOS.
+
+## 5. Verification
+- `uv run pytest -q` — all existing 150 + new tests green.
+- `uv run ruff check src tests` — clean.
+- Spot-check `hotmem inspect --json <fixture>` output shape.

--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -264,6 +264,76 @@ def openapi(output: str | None, fmt: str):
 
 
 @main.command()
+@click.argument("uri")
+@click.option(
+    "--count-rows",
+    is_flag=True,
+    help=(
+        "Compute row counts where cheap (CSV/JSONL). "
+        "Parquet row count always comes from the footer."
+    ),
+)
+@click.option(
+    "--sample",
+    "sample_size",
+    default=5,
+    type=int,
+    help="Max sample rows to preview (CSV/JSONL).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit raw JSON (bypasses the renderer, for scripting).",
+)
+def inspect(uri: str, count_rows: bool, sample_size: int, as_json: bool):
+    """Inspect a local file's structure and provenance without ingesting it.
+
+    Lightweight metadata-only inspection for CSV, JSONL, and Parquet files.
+    Never copies file contents into the database — returns URI, size, checksum,
+    columns, and an optional bounded sample. Unsupported formats and remote
+    schemes fail with a clear error.
+    """
+    from hotmem.inspectors import UnsupportedFormatError, inspect_file
+    from hotmem.storage import UnsupportedSchemeError
+
+    try:
+        inspection = inspect_file(uri, count_rows=count_rows, sample_size=sample_size)
+    except UnsupportedFormatError as err:
+        raise click.ClickException(str(err)) from err
+    except UnsupportedSchemeError as err:
+        raise click.ClickException(str(err)) from err
+
+    data = inspection.to_dict()
+
+    if as_json:
+        click.echo(json.dumps(data, indent=2, default=str))
+        return
+
+    ui = get_renderer()
+    ui.summary(
+        "inspect",
+        format=data["format"],
+        size=data["size"],
+        rows=data["row_count"],
+        checksum=str(data["checksum"])[:12] + "…",
+    )
+    if data["columns"]:
+        click.echo(f"columns: {', '.join(data['columns'])}")
+    if data["delimiter"]:
+        click.echo(f"delimiter: {data['delimiter']!r}  has_header: {data['has_header']}")
+    if data["num_row_groups"] is not None:
+        types = ", ".join(data["schema_types"] or [])
+        click.echo(f"row_groups: {data['num_row_groups']}  schema_types: {types}")
+    if data["sample"]:
+        click.echo("sample:")
+        for row in data["sample"]:
+            click.echo("  " + json.dumps(row, default=str))
+    if data["unsupported_reason"]:
+        click.echo(f"warning: {data['unsupported_reason']}", err=True)
+
+
+@main.command()
 @click.option("--db", "db_path", default=None, type=click.Path(), help="Database file path.")
 @click.option("--url", default=None, help="Running server URL (e.g. http://127.0.0.1:8711).")
 def playground(db_path: str | None, url: str | None):

--- a/src/hotmem/inspectors/__init__.py
+++ b/src/hotmem/inspectors/__init__.py
@@ -1,0 +1,100 @@
+"""HotMem file inspectors — lightweight, read-only, no query engine (issue #53).
+
+Purpose:
+    Understand *about* large local files (CSV, JSONL, Parquet) enough to
+    reference, hydrate ranges, and expose provenance — without becoming
+    DuckDB, Polars, Arrow, or a data lake, and without copying large file
+    contents into SQLite.
+
+Interface:
+    inspect_file(uri, *, count_rows=False, sample_size=5) -> FileInspection
+    get_inspector(uri) -> FileInspector
+    UnsupportedFormatError — raised when no inspector handles a format
+
+Deps: hotmem.storage, hotmem.inspectors.{csv,jsonl,parquet}
+Extension: register a new inspector by format name in INSPECTORS below.
+"""
+
+from __future__ import annotations
+
+from hotmem.storage import UnsupportedSchemeError
+
+from .base import FileInspection, FileInspector, resolve_adapter
+from .csv_inspector import CSVInspector
+from .jsonl_inspector import JSONLInspector
+from .parquet_inspector import ParquetInspector
+
+__all__ = [
+    "FileInspector",
+    "FileInspection",
+    "CSVInspector",
+    "JSONLInspector",
+    "ParquetInspector",
+    "UnsupportedFormatError",
+    "inspect_file",
+    "get_inspector",
+]
+
+INSPECTORS: dict[str, FileInspector] = {
+    "csv": CSVInspector(),
+    "jsonl": JSONLInspector(),
+    "parquet": ParquetInspector(),
+}
+
+
+class UnsupportedFormatError(ValueError):
+    """Raised when a backing file's format has no HotMem inspector.
+
+    Mirrors hotmem.storage.UnsupportedSchemeError so the two failure modes
+    feel symmetrical to callers. Analytical execution (DuckDB/Polars/Arrow
+    query) is owned by EMOS, not HotMem.
+    """
+
+
+def get_inspector(uri: str) -> FileInspector:
+    """Return the inspector for ``uri``'s format, or raise.
+
+    Resolves the storage adapter first so remote/unsupported schemes fail fast
+    with the existing EMOS-boundary UnsupportedSchemeError before we look at
+    format.
+    """
+    _, meta = resolve_adapter(uri)
+    fmt = meta["format"]
+    inspector = INSPECTORS.get(fmt)
+    if inspector is None:
+        raise UnsupportedFormatError(
+            f"no inspector for format {fmt!r}; "
+            "analytical execution (DuckDB/Polars/Arrow) is owned by EMOS, not HotMem"
+        )
+    return inspector
+
+
+def inspect_file(
+    uri: str,
+    *,
+    count_rows: bool = False,
+    sample_size: int = 5,
+) -> FileInspection:
+    """Inspect a backing file and return provenance + light metadata.
+
+    Never copies large file contents into SQLite; the inspectors stream or
+    read only the file's metadata/footer. ``UnsupportedSchemeError`` is
+    raised for remote schemes; ``UnsupportedFormatError`` for unknown
+    formats; otherwise a FileInspection (which may carry
+    ``unsupported_reason`` for a recognized-but-malformed file).
+    """
+    try:
+        adapter, meta = resolve_adapter(uri)
+    except UnsupportedSchemeError:
+        raise
+
+    fmt = meta["format"]
+    inspector = INSPECTORS.get(fmt)
+    if inspector is None:
+        raise UnsupportedFormatError(
+            f"no inspector for format {fmt!r}; "
+            "analytical execution (DuckDB/Polars/Arrow) is owned by EMOS, not HotMem"
+        )
+    return inspector.inspect(
+        uri, adapter, meta, count_rows=count_rows, sample_size=sample_size
+    )

--- a/src/hotmem/inspectors/__init__.py
+++ b/src/hotmem/inspectors/__init__.py
@@ -17,7 +17,7 @@ Extension: register a new inspector by format name in INSPECTORS below.
 
 from __future__ import annotations
 
-from hotmem.storage import UnsupportedSchemeError
+from hotmem.storage import UnsupportedSchemeError  # noqa: F401 — re-exported for callers
 
 from .base import FileInspection, FileInspector, resolve_adapter
 from .csv_inspector import CSVInspector
@@ -59,7 +59,12 @@ def get_inspector(uri: str) -> FileInspector:
     format.
     """
     _, meta = resolve_adapter(uri)
-    fmt = meta["format"]
+    inspector = _inspector_for_format(meta["format"])
+    return inspector
+
+
+def _inspector_for_format(fmt: str) -> FileInspector:
+    """Look up an inspector by format name, or raise UnsupportedFormatError."""
     inspector = INSPECTORS.get(fmt)
     if inspector is None:
         raise UnsupportedFormatError(
@@ -83,16 +88,6 @@ def inspect_file(
     formats; otherwise a FileInspection (which may carry
     ``unsupported_reason`` for a recognized-but-malformed file).
     """
-    try:
-        adapter, meta = resolve_adapter(uri)
-    except UnsupportedSchemeError:
-        raise
-
-    fmt = meta["format"]
-    inspector = INSPECTORS.get(fmt)
-    if inspector is None:
-        raise UnsupportedFormatError(
-            f"no inspector for format {fmt!r}; "
-            "analytical execution (DuckDB/Polars/Arrow) is owned by EMOS, not HotMem"
-        )
+    adapter, meta = resolve_adapter(uri)
+    inspector = _inspector_for_format(meta["format"])
     return inspector.inspect(uri, adapter, meta, count_rows=count_rows, sample_size=sample_size)

--- a/src/hotmem/inspectors/__init__.py
+++ b/src/hotmem/inspectors/__init__.py
@@ -95,6 +95,4 @@ def inspect_file(
             f"no inspector for format {fmt!r}; "
             "analytical execution (DuckDB/Polars/Arrow) is owned by EMOS, not HotMem"
         )
-    return inspector.inspect(
-        uri, adapter, meta, count_rows=count_rows, sample_size=sample_size
-    )
+    return inspector.inspect(uri, adapter, meta, count_rows=count_rows, sample_size=sample_size)

--- a/src/hotmem/inspectors/_thrift.py
+++ b/src/hotmem/inspectors/_thrift.py
@@ -129,9 +129,9 @@ class ThriftCompactReader:
         size = header >> 4
         element_type = header & 0x0F
         if size == 0x0F:
+            # The element type is in the low nibble of the header byte;
+            # only the size is a varint per the Compact Protocol spec.
             size = self._read_varint()
-            # When size==15 the element type byte follows separately.
-            element_type = self._read_byte()
         return [self.read_value(element_type) for _ in range(size)]
 
     def read_map(self) -> dict[Any, Any]:

--- a/src/hotmem/inspectors/_thrift.py
+++ b/src/hotmem/inspectors/_thrift.py
@@ -1,0 +1,174 @@
+"""Minimal Thrift Compact Protocol reader (production, dependency-free).
+
+Purpose:
+    Read only what HotMem needs from a Parquet footer (``FileMetaData``)
+    without pulling in a Thrift runtime or pyarrow. This is the dependency-free
+    bet behind issue #53: Parquet *provenance* with zero new deps.
+
+Scope:
+    Implements the subset of the Thrift Compact Protocol required to decode
+    Parquet ``FileMetaData`` (structs, ints/i64, lists, strings, and stop).
+    It is intentionally *not* a general Thrift implementation — it reads
+    forward only and tolerates unknown fields by skipping them via the wire
+    type tags.
+
+Reference: Apache Thrift Compact Protocol specification; Apache Parquet
+``parquet.thrift`` FileMetaData struct.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+
+# Compact protocol wire type ids (low nibble of the field header byte).
+_CT_STOP = 0x00
+_CT_BOOL_TRUE = 0x01
+_CT_BOOL_FALSE = 0x02
+_CT_BYTE = 0x03
+_CT_I16 = 0x04
+_CT_I32 = 0x05
+_CT_I64 = 0x06
+_CT_DOUBLE = 0x07
+_CT_BINARY = 0x08  # also STRING
+_CT_LIST = 0x09
+_CT_SET = 0x0A
+_CT_MAP = 0x0B
+_CT_STRUCT = 0x0C
+
+_TYPE_NAMES = {
+    _CT_STOP: "stop",
+    _CT_BOOL_TRUE: "bool",
+    _CT_BOOL_FALSE: "bool",
+    _CT_BYTE: "byte",
+    _CT_I16: "i16",
+    _CT_I32: "i32",
+    _CT_I64: "i64",
+    _CT_DOUBLE: "double",
+    _CT_BINARY: "string",
+    _CT_LIST: "list",
+    _CT_SET: "set",
+    _CT_MAP: "map",
+    _CT_STRUCT: "struct",
+}
+
+
+class ThriftCompactReader:
+    """Forward-only reader over a Thrift Compact Protocol byte buffer."""
+
+    __slots__ = ("buf", "pos")
+
+    def __init__(self, buf: bytes) -> None:
+        self.buf = buf
+        self.pos = 0
+
+    # ── low-level primitives ───────────────────────────────────────────────
+
+    def _read_byte(self) -> int:
+        b = self.buf[self.pos]
+        self.pos += 1
+        return b
+
+    def _read_varint(self) -> int:
+        """Decode a Thrift Compact zigzag varint."""
+        shift = 0
+        result = 0
+        while True:
+            b = self.buf[self.pos]
+            self.pos += 1
+            result |= (b & 0x7F) << shift
+            if not (b & 0x80):
+                break
+            shift += 7
+            if shift > 63:
+                raise ValueError("varint too long")
+        # zigzag decode
+        return (result >> 1) ^ -(result & 1)
+
+    def _read_bytes(self, n: int) -> bytes:
+        chunk = self.buf[self.pos : self.pos + n]
+        if len(chunk) != n:
+            raise ValueError("short read in thrift buffer")
+        self.pos += n
+        return chunk
+
+    # ── typed value readers ───────────────────────────────────────────────
+
+    def read_value(self, wire_type: int) -> Any:
+        if wire_type in (_CT_BOOL_TRUE, _CT_BOOL_FALSE):
+            return wire_type == _CT_BOOL_TRUE
+        if wire_type == _CT_BYTE:
+            return self._read_signed_byte()
+        if wire_type == _CT_I16:
+            return self._read_varint()
+        if wire_type == _CT_I32:
+            return self._read_varint()
+        if wire_type == _CT_I64:
+            return self._read_varint()
+        if wire_type == _CT_DOUBLE:
+            return struct.unpack("<d", self._read_bytes(8))[0]
+        if wire_type == _CT_BINARY:
+            n = self._read_varint()
+            return self._read_bytes(n).decode("utf-8", errors="replace")
+        if wire_type == _CT_LIST:
+            return self.read_list()
+        if wire_type == _CT_SET:
+            return self.read_list()
+        if wire_type == _CT_MAP:
+            return self.read_map()
+        if wire_type == _CT_STRUCT:
+            return self.read_struct()
+        raise ValueError(f"unsupported thrift wire type {wire_type}")
+
+    def _read_signed_byte(self) -> int:
+        b = self._read_byte()
+        return b - 256 if b > 127 else b
+
+    def read_list(self) -> list[Any]:
+        header = self._read_byte()
+        size = header >> 4
+        element_type = header & 0x0F
+        if size == 0x0F:
+            size = self._read_varint()
+            # When size==15 the element type byte follows separately.
+            element_type = self._read_byte()
+        return [self.read_value(element_type) for _ in range(size)]
+
+    def read_map(self) -> dict[Any, Any]:
+        size = self._read_varint()
+        if size == 0:
+            return {}
+        kv_header = self._read_byte()
+        key_type = (kv_header >> 4) & 0x0F
+        val_type = kv_header & 0x0F
+        out: dict[Any, Any] = {}
+        for _ in range(size):
+            k = self.read_value(key_type)
+            v = self.read_value(val_type)
+            out[k] = v
+        return out
+
+    def read_struct(self) -> dict[str, Any]:
+        """Read a struct as a dict keyed by integer field id.
+
+        Unknown fields are decoded by wire type so we can skip them without a
+        schema — this is what makes the reader robust to Parquet version drift.
+        """
+        out: dict[str, Any] = {}
+        last_field = 0
+        while True:
+            if self.pos >= len(self.buf):
+                break
+            header = self._read_byte()
+            if header == _CT_STOP:
+                break
+            wire_type = header & 0x0F
+            delta = header >> 4
+            field_id = self._read_varint() if delta == 0 else last_field + delta
+            last_field = field_id
+            out[str(field_id)] = self.read_value(wire_type)
+        return out
+
+
+def type_name(wire_type: int) -> str:
+    return _TYPE_NAMES.get(wire_type, f"type{wire_type}")

--- a/src/hotmem/inspectors/base.py
+++ b/src/hotmem/inspectors/base.py
@@ -1,0 +1,96 @@
+"""Inspector interfaces for lightweight file-native inspection (issue #53).
+
+Purpose:
+    Define the contract every file inspector implements and the FileInspection
+    result shape. Inspectors understand *about* a file (headers, size, row
+    counts, schema, byte ranges) without becoming a query engine and without
+    copying large file contents into SQLite.
+
+Interface:
+    FileInspector (Protocol): inspect(uri, adapter, ...) -> FileInspection
+    FileInspection: provenance + format-specific metadata dataclass
+    inspect_file(uri, *, count_rows=False, sample_size=5) -> FileInspection
+
+Deps: hotmem.storage
+Extension: register a new inspector in hotmem.inspectors.__init__.ADAPTER_INSPECTORS.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from hotmem.storage import StorageAdapter, StorageMetadata, get_adapter
+
+
+@dataclass(frozen=True)
+class FileInspection:
+    """Provenance + format-specific metadata for a backing file.
+
+    Designed so a future file-backed memory (#38) can store this directly:
+    URI, size, mtime, checksum (provenance) plus light format metadata and
+    optional sample byte ranges. No large content is ever materialized here.
+    """
+
+    uri: str
+    format: str
+    size: int
+    mtime: float
+    checksum: str
+    columns: list[str] | None = None
+    row_count: int | None = None
+    delimiter: str | None = None
+    has_header: bool | None = None
+    num_row_groups: int | None = None
+    schema_types: list[str] | None = None
+    sample: list[dict[str, Any]] | None = None
+    byte_ranges: list[tuple[int, int]] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    unsupported_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe dict for CLI/API/MCP consumption."""
+        return {
+            "uri": self.uri,
+            "format": self.format,
+            "size": self.size,
+            "mtime": self.mtime,
+            "checksum": self.checksum,
+            "columns": self.columns,
+            "row_count": self.row_count,
+            "delimiter": self.delimiter,
+            "has_header": self.has_header,
+            "num_row_groups": self.num_row_groups,
+            "schema_types": self.schema_types,
+            "sample": self.sample,
+            "byte_ranges": self.byte_ranges,
+            "metadata": self.metadata,
+            "unsupported_reason": self.unsupported_reason,
+        }
+
+
+@runtime_checkable
+class FileInspector(Protocol):
+    """Read-only metadata inspector for one backing-file format."""
+
+    def inspect(
+        self,
+        uri: str,
+        adapter: StorageAdapter,
+        meta: StorageMetadata,
+        *,
+        count_rows: bool = False,
+        sample_size: int = 5,
+    ) -> FileInspection: ...
+
+
+def resolve_adapter(uri: str) -> tuple[StorageAdapter, StorageMetadata]:
+    """Return (adapter, metadata) for ``uri``, failing fast on remote schemes.
+
+    Reuses hotmem.storage so unsupported remote schemes (s3://, hdfs://, ...)
+    raise the existing EMOS-boundary UnsupportedSchemeError before any
+    inspector runs.
+    """
+    adapter = get_adapter(uri)
+    meta = adapter.metadata(uri)
+    return adapter, meta

--- a/src/hotmem/inspectors/csv_inspector.py
+++ b/src/hotmem/inspectors/csv_inspector.py
@@ -127,7 +127,7 @@ def _all_numeric(row: list[str]) -> bool:
 
 def _resolve(uri: str) -> Path:
     if uri.startswith("file://"):
-        return Path(uri[len("file://"):])
+        return Path(uri[len("file://") :])
     return Path(uri)
 
 

--- a/src/hotmem/inspectors/csv_inspector.py
+++ b/src/hotmem/inspectors/csv_inspector.py
@@ -1,0 +1,178 @@
+"""CSV inspector — streaming header/delimiter detection, no full-file load.
+
+Scope (#53):
+    - Detect headers and delimiter basics.
+    - Report size (from storage metadata) and columns.
+    - Optional row count when ``count_rows=True`` (streaming newline scan).
+    - Bounded sample of the first ``sample_size`` data rows.
+    - Never copy file contents into SQLite; never load the whole file into RAM.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from itertools import islice
+from pathlib import Path
+from typing import Any
+
+from hotmem.storage import StorageAdapter, StorageMetadata
+
+from .base import FileInspection
+
+_SNIFF_BYTES = 8192
+_DEFAULT_DELIMITER = ","
+
+
+class CSVInspector:
+    """Inspect a CSV file's structure with O(head buffer) memory."""
+
+    def inspect(
+        self,
+        uri: str,
+        adapter: StorageAdapter,
+        meta: StorageMetadata,
+        *,
+        count_rows: bool = False,
+        sample_size: int = 5,
+    ) -> FileInspection:
+        head = adapter.read_range(uri, 0, min(_SNIFF_BYTES, meta["size"] or 0))
+        text = head.decode("utf-8", errors="replace")
+
+        delimiter, has_header, columns = self._sniff(text)
+
+        sample_rows, byte_ranges, row_count = _scan(
+            uri, columns, delimiter, has_header, count_rows, sample_size
+        )
+
+        return FileInspection(
+            uri=uri,
+            format="csv",
+            size=meta["size"],
+            mtime=meta["mtime"],
+            checksum=adapter.checksum(uri),
+            columns=columns,
+            row_count=row_count,
+            delimiter=delimiter,
+            has_header=has_header,
+            sample=sample_rows or None,
+            byte_ranges=byte_ranges or None,
+            metadata={},
+        )
+
+    @staticmethod
+    def _sniff(head_text: str) -> tuple[str, bool, list[str]]:
+        """Best-effort delimiter + header detection from a head buffer."""
+        sample = io.StringIO(head_text)
+        try:
+            dialect = csv.Sniffer().sniff(head_text, delimiters=",;\t|")
+            delimiter = dialect.delimiter
+        except csv.Error:
+            delimiter = _DEFAULT_DELIMITER
+
+        sample.seek(0)
+        reader = csv.reader(sample, delimiter=delimiter)
+        rows = [row for row in islice(reader, 3) if row]
+
+        if not rows:
+            return delimiter, None, []
+
+        first = rows[0]
+        has_header = _detect_header(head_text, delimiter, first, rows[1] if len(rows) > 1 else None)
+
+        if has_header:
+            columns = [c.strip() for c in first]
+        else:
+            columns = [f"col_{i}" for i in range(len(first))]
+        return delimiter, has_header, columns
+
+
+def _detect_header(
+    head_text: str,
+    delimiter: str,
+    first: list[str],
+    second: list[str] | None,
+) -> bool:
+    """Detect whether the first row is a header row.
+
+    Prefers csv.Sniffer.has_header; falls back to a cheap type-based heuristic
+    so a single data row or a numeric-only file still classifies correctly.
+    """
+    try:
+        if csv.Sniffer().has_header(head_text):
+            return True
+    except csv.Error:
+        pass
+    # Fallback: a header row has no empty cells and is not all-numeric, while a
+    # following data row either is numeric or has a different shape.
+    if any(not c.strip() for c in first):
+        return False
+    if _all_numeric(first):
+        return False
+    if second is None:
+        return True
+    return True
+
+
+def _all_numeric(row: list[str]) -> bool:
+    if not row:
+        return False
+    for c in row:
+        try:
+            float(c.strip())
+        except ValueError:
+            return False
+    return True
+
+
+def _resolve(uri: str) -> Path:
+    if uri.startswith("file://"):
+        return Path(uri[len("file://"):])
+    return Path(uri)
+
+
+def _scan(
+    uri: str,
+    columns: list[str],
+    delimiter: str,
+    has_header: bool | None,
+    count_rows: bool,
+    sample_size: int,
+) -> tuple[list[dict[str, Any]], list[tuple[int, int]], int | None]:
+    """Stream the file once to collect a bounded sample and optional row count.
+
+    Memory is O(sample_size rows); the file is read in a single streaming pass.
+    Byte ranges for sampled rows are recorded for provenance (#38 enabler).
+    """
+    path = _resolve(uri)
+    sample_rows: list[dict[str, Any]] = []
+    byte_ranges: list[tuple[int, int]] = []
+    row_count = 0 if count_rows else None
+    collected = 0
+    offset = 0
+
+    with open(path, "rb") as f:
+        line_iter = iter(f)
+        # Skip the header line from sampling/counting if one was detected.
+        if has_header:
+            header_line = next(line_iter, b"")
+            offset += len(header_line)
+
+        for raw in line_iter:
+            line_len = len(raw)
+            if collected < sample_size:
+                text = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+                if text:
+                    cells = next(csv.reader([text], delimiter=delimiter))
+                    row_dict: dict[str, Any] = {}
+                    for i, val in enumerate(cells):
+                        key = columns[i] if i < len(columns) else f"col_{i}"
+                        row_dict[key] = val
+                    sample_rows.append(row_dict)
+                    byte_ranges.append((offset, line_len))
+                    collected += 1
+            if count_rows and raw.strip():
+                row_count = (row_count or 0) + 1
+            offset += line_len
+
+    return sample_rows, byte_ranges, row_count

--- a/src/hotmem/inspectors/csv_inspector.py
+++ b/src/hotmem/inspectors/csv_inspector.py
@@ -131,6 +131,33 @@ def _resolve(uri: str) -> Path:
     return Path(uri)
 
 
+class _ByteTrackingLineReader:
+    """Wrap a binary file line iterator, yielding decoded lines + byte offsets.
+
+    This lets a single ``csv.reader`` handle quoted fields with embedded
+    newlines (the csv module pulls extra lines as needed) while we still
+    track the cumulative byte offset of each logical line for provenance.
+    """
+
+    __slots__ = ("_lines", "_offset")
+
+    def __init__(self, f) -> None:
+        self._lines = f
+        self._offset = 0
+
+    def __iter__(self) -> _ByteTrackingLineReader:
+        return self
+
+    def __next__(self) -> str:
+        raw = next(self._lines)
+        self._offset += len(raw)
+        return raw.decode("utf-8", errors="replace")
+
+    @property
+    def offset(self) -> int:
+        return self._offset
+
+
 def _scan(
     uri: str,
     columns: list[str],
@@ -139,7 +166,7 @@ def _scan(
     count_rows: bool,
     sample_size: int,
 ) -> tuple[list[dict[str, Any]], list[tuple[int, int]], int | None]:
-    """Stream the file once to collect a bounded sample and optional row count.
+    """Stream the file once via a single csv.reader (handles quoted newlines).
 
     Memory is O(sample_size rows); the file is read in a single streaming pass.
     Byte ranges for sampled rows are recorded for provenance (#38 enabler).
@@ -149,30 +176,36 @@ def _scan(
     byte_ranges: list[tuple[int, int]] = []
     row_count = 0 if count_rows else None
     collected = 0
-    offset = 0
 
     with open(path, "rb") as f:
-        line_iter = iter(f)
-        # Skip the header line from sampling/counting if one was detected.
-        if has_header:
-            header_line = next(line_iter, b"")
-            offset += len(header_line)
+        tracker = _ByteTrackingLineReader(f)
+        reader = csv.reader(tracker, delimiter=delimiter)
 
-        for raw in line_iter:
-            line_len = len(raw)
-            if collected < sample_size:
-                text = raw.decode("utf-8", errors="replace").rstrip("\r\n")
-                if text:
-                    cells = next(csv.reader([text], delimiter=delimiter))
-                    row_dict: dict[str, Any] = {}
-                    for i, val in enumerate(cells):
-                        key = columns[i] if i < len(columns) else f"col_{i}"
-                        row_dict[key] = val
-                    sample_rows.append(row_dict)
-                    byte_ranges.append((offset, line_len))
-                    collected += 1
-            if count_rows and raw.strip():
+        row_iter = iter(reader)
+        # Skip the header line if one was detected.
+        if has_header:
+            next(row_iter, None)
+
+        for row in row_iter:
+            # Byte offset at the *end* of this record; the start is the
+            # previous end (or 0 for the first data row).
+            end_offset = tracker.offset
+            # Approximate the start offset by subtracting the bytes of the
+            # row's serialized form. This is exact for simple rows and close
+            # enough for provenance; the csv module doesn't expose exact
+            # byte positions for multi-line records.
+            row_bytes = sum(len(cell) + 1 for cell in row)  # cells + delimiters
+            start_offset = max(0, end_offset - row_bytes)
+
+            if collected < sample_size and row:
+                row_dict: dict[str, Any] = {}
+                for i, val in enumerate(row):
+                    key = columns[i] if i < len(columns) else f"col_{i}"
+                    row_dict[key] = val
+                sample_rows.append(row_dict)
+                byte_ranges.append((start_offset, end_offset - start_offset))
+                collected += 1
+            if count_rows and row:
                 row_count = (row_count or 0) + 1
-            offset += line_len
 
     return sample_rows, byte_ranges, row_count

--- a/src/hotmem/inspectors/jsonl_inspector.py
+++ b/src/hotmem/inspectors/jsonl_inspector.py
@@ -1,0 +1,188 @@
+"""JSONL inspector — streamed line count + seek-based range sampling.
+
+Scope (#53):
+    - Stream line counts and selected ranges without full ingestion.
+    - Validate sampled lines are JSON; report the first malformed line offset
+      in ``unsupported_reason`` instead of crashing (provenance, not outage).
+    - O(file size) byte read, O(1) memory via buffered newline scanning.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hotmem.storage import StorageAdapter, StorageMetadata
+
+from .base import FileInspection
+
+_READ_CHUNK = 1 << 20  # 1 MiB read window — constant memory regardless of file size.
+
+
+class JSONLInspector:
+    """Inspect a JSONL file's structure with O(1) streaming memory."""
+
+    def inspect(
+        self,
+        uri: str,
+        adapter: StorageAdapter,
+        meta: StorageMetadata,
+        *,
+        count_rows: bool = False,
+        sample_size: int = 5,
+    ) -> FileInspection:
+        row_count: int | None
+        sample_rows: list[dict[str, Any]] = []
+        byte_ranges: list[tuple[int, int]] = []
+        unsupported_reason: str | None = None
+
+        path = _resolve(uri)
+        row_count, sample_rows, byte_ranges, unsupported_reason = _stream(
+            path, count_rows=count_rows, sample_size=sample_size
+        )
+
+        columns = _infer_columns(sample_rows)
+
+        return FileInspection(
+            uri=uri,
+            format="jsonl",
+            size=meta["size"],
+            mtime=meta["mtime"],
+            checksum=adapter.checksum(uri),
+            columns=columns,
+            row_count=row_count,
+            delimiter="\n",
+            has_header=None,
+            sample=sample_rows or None,
+            byte_ranges=byte_ranges or None,
+            metadata={},
+            unsupported_reason=unsupported_reason,
+        )
+
+
+def _resolve(uri: str) -> Path:
+    if uri.startswith("file://"):
+        return Path(uri[len("file://"):])
+    return Path(uri)
+
+
+def _stream(
+    path: Path,
+    *,
+    count_rows: bool,
+    sample_size: int,
+) -> tuple[int | None, list[dict[str, Any]], list[tuple[int, int]], str | None]:
+    """One streaming pass: count lines, collect a bounded sample, validate JSON.
+
+    Counts newlines in fixed-size chunks (cheap, allocation-free) and samples
+    the first ``sample_size`` complete records by capturing byte offsets.
+    """
+    row_count = 0 if count_rows else None
+    sample_rows: list[dict[str, Any]] = []
+    byte_ranges: list[tuple[int, int]] = []
+    unsupported_reason: str | None = None
+
+    line_index = 0
+    line_start = 0
+    carry = b""
+
+    with open(path, "rb") as f:
+        offset = 0
+        while True:
+            chunk = f.read(_READ_CHUNK)
+            if not chunk:
+                # Final partial line without a trailing newline.
+                if carry:
+                    if count_rows and carry.strip():
+                        row_count = (row_count or 0) + 1
+                    if unsupported_reason is None:
+                        unsupported_reason = _validate(carry, line_index, line_start)
+                    _handle_line(
+                        carry,
+                        line_index,
+                        line_start,
+                        len(carry),
+                        sample_size,
+                        sample_rows,
+                        byte_ranges,
+                    )
+                break
+
+            data = carry + chunk
+            chunk_end = offset + len(chunk)
+            pos = 0
+            nl = data.find(b"\n", pos)
+            while nl != -1:
+                complete = data[pos : nl + 1]
+                line_len = len(complete)
+                if count_rows and complete.strip():
+                    row_count = (row_count or 0) + 1
+                if unsupported_reason is None:
+                    unsupported_reason = _validate(complete, line_index, line_start)
+                _handle_line(
+                    complete,
+                    line_index,
+                    line_start,
+                    line_len,
+                    sample_size,
+                    sample_rows,
+                    byte_ranges,
+                )
+                line_index += 1
+                pos = nl + 1
+                line_start = offset + pos
+                nl = data.find(b"\n", pos)
+            carry = data[pos:]
+            offset = chunk_end
+
+    return row_count, sample_rows, byte_ranges, unsupported_reason
+
+
+def _handle_line(
+    raw: bytes,
+    line_index: int,
+    line_start: int,
+    line_len: int,
+    sample_size: int,
+    sample_rows: list[dict[str, Any]],
+    byte_ranges: list[tuple[int, int]],
+) -> None:
+    """Append one complete line to the bounded sample if it parses as JSON."""
+    if line_index >= sample_size:
+        return
+    text = raw.decode("utf-8", errors="replace").strip()
+    if not text:
+        return
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        return
+    if isinstance(obj, dict):
+        sample_rows.append(obj)
+    else:
+        sample_rows.append({"value": obj})
+    byte_ranges.append((line_start, line_len))
+
+
+def _validate(raw: bytes, line_index: int, line_start: int) -> str | None:
+    """Return a human-readable reason if a line is not valid JSON, else None."""
+    text = raw.decode("utf-8", errors="replace").strip()
+    if not text:
+        return None
+    try:
+        json.loads(text)
+    except json.JSONDecodeError as err:
+        return f"line {line_index} (offset {line_start}): {err.msg}"
+    return None
+
+
+def _infer_columns(sample_rows: list[dict[str, Any]]) -> list[str] | None:
+    """Union of keys across the sample, in first-seen order."""
+    if not sample_rows:
+        return None
+    seen: dict[str, None] = {}
+    for row in sample_rows:
+        for k in row:
+            seen.setdefault(k, None)
+    return list(seen)

--- a/src/hotmem/inspectors/jsonl_inspector.py
+++ b/src/hotmem/inspectors/jsonl_inspector.py
@@ -32,11 +32,6 @@ class JSONLInspector:
         count_rows: bool = False,
         sample_size: int = 5,
     ) -> FileInspection:
-        row_count: int | None
-        sample_rows: list[dict[str, Any]] = []
-        byte_ranges: list[tuple[int, int]] = []
-        unsupported_reason: str | None = None
-
         path = _resolve(uri)
         row_count, sample_rows, byte_ranges, unsupported_reason = _stream(
             path, count_rows=count_rows, sample_size=sample_size

--- a/src/hotmem/inspectors/jsonl_inspector.py
+++ b/src/hotmem/inspectors/jsonl_inspector.py
@@ -63,7 +63,7 @@ class JSONLInspector:
 
 def _resolve(uri: str) -> Path:
     if uri.startswith("file://"):
-        return Path(uri[len("file://"):])
+        return Path(uri[len("file://") :])
     return Path(uri)
 
 

--- a/src/hotmem/inspectors/parquet_inspector.py
+++ b/src/hotmem/inspectors/parquet_inspector.py
@@ -1,0 +1,175 @@
+"""Parquet inspector — metadata-only footer reader, no query engine (issue #53).
+
+Scope (#53 + file-aware-architecture.md §4):
+    - Validate PAR1 magic at head and tail.
+    - Read the Thrift-Compact ``FileMetaData`` footer and extract: version,
+      num_rows, schema (column names + physical types), row_group count.
+    - **No data-page decoding, no query engine, no pyarrow dependency.**
+    - Malformed or hostile footers set ``unsupported_reason`` rather than
+      raising, so a bad file becomes provenance, not an outage.
+
+The dependency-free footer reader lives in ``_thrift.py``.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from hotmem.storage import StorageAdapter, StorageMetadata
+
+from ._thrift import ThriftCompactReader
+from .base import FileInspection
+
+_PARQUET_MAGIC = b"PAR1"
+_TAIL_LEN = 8  # 4-byte footer length + 4-byte trailing magic
+_MAX_FOOTER = 1 << 30  # reject footers claiming > 1 GiB (hostile-file guard)
+
+# Parquet physical Type enum (parquet.thrift).
+_PARQUET_TYPE = {
+    0: "BOOLEAN",
+    1: "INT32",
+    2: "INT64",
+    3: "INT96",
+    4: "FLOAT",
+    5: "DOUBLE",
+    6: "BYTE_ARRAY",
+    7: "FIXED_LEN_BYTE_ARRAY",
+}
+
+# FileMetaData field ids (parquet.thrift).
+_FM_VERSION = "1"
+_FM_SCHEMA = "2"
+_FM_NUM_ROWS = "3"
+_FM_ROW_GROUPS = "4"
+
+# SchemaElement field ids.
+_SE_TYPE = "1"
+_SE_NAME = "4"
+_SE_NUM_CHILDREN = "5"
+
+
+class ParquetInspector:
+    """Inspect a Parquet file's footer metadata only."""
+
+    def inspect(
+        self,
+        uri: str,
+        adapter: StorageAdapter,
+        meta: StorageMetadata,
+        *,
+        count_rows: bool = False,  # noqa: ARG002 — num_rows comes from the footer
+        sample_size: int = 0,  # noqa: ARG002 — no row sampling (metadata-only)
+    ) -> FileInspection:
+        size = meta["size"]
+        unsupported = self._validate_magic(adapter, uri, size)
+        if unsupported:
+            return FileInspection(
+                uri=uri,
+                format="parquet",
+                size=size,
+                mtime=meta["mtime"],
+                checksum=adapter.checksum(uri),
+                unsupported_reason=unsupported,
+            )
+
+        footer = self._read_footer(adapter, uri, size)
+        if isinstance(footer, str):
+            return FileInspection(
+                uri=uri,
+                format="parquet",
+                size=size,
+                mtime=meta["mtime"],
+                checksum=adapter.checksum(uri),
+                unsupported_reason=footer,
+            )
+
+        parsed = self._parse_footer(footer)
+        if isinstance(parsed, str):
+            return FileInspection(
+                uri=uri,
+                format="parquet",
+                size=size,
+                mtime=meta["mtime"],
+                checksum=adapter.checksum(uri),
+                unsupported_reason=parsed,
+            )
+
+        version, num_rows, columns, schema_types, num_row_groups = parsed
+        return FileInspection(
+            uri=uri,
+            format="parquet",
+            size=size,
+            mtime=meta["mtime"],
+            checksum=adapter.checksum(uri),
+            columns=columns,
+            row_count=num_rows,
+            num_row_groups=num_row_groups,
+            schema_types=schema_types,
+            metadata={"version": version},
+        )
+
+    # ── helpers ───────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _validate_magic(adapter: StorageAdapter, uri: str, size: int) -> str | None:
+        if size < 12:
+            return f"file too small ({size} bytes) to be a valid Parquet file"
+        head = adapter.read_range(uri, 0, 4)
+        if head != _PARQUET_MAGIC:
+            return f"missing leading PAR1 magic (got {head!r})"
+        tail = adapter.read_range(uri, size - 4, 4)
+        if tail != _PARQUET_MAGIC:
+            return f"missing trailing PAR1 magic (got {tail!r})"
+        return None
+
+    @staticmethod
+    def _read_footer(adapter: StorageAdapter, uri: str, size: int) -> bytes | str:
+        tail = adapter.read_range(uri, size - _TAIL_LEN, _TAIL_LEN)
+        footer_length = struct.unpack("<I", tail[:4])[0]
+        if footer_length <= 0 or footer_length > _MAX_FOOTER:
+            return f"implausible footer length {footer_length}"
+        available = size - _TAIL_LEN
+        if footer_length > available:
+            return f"footer length {footer_length} exceeds available bytes {available}"
+        offset = available - footer_length
+        return adapter.read_range(uri, offset, footer_length)
+
+    @staticmethod
+    def _parse_footer(
+        footer: bytes,
+    ) -> tuple[int, int | None, list[str], list[str], int | None] | str:
+        try:
+            reader = ThriftCompactReader(footer)
+            fm = reader.read_struct()
+        except (ValueError, IndexError) as err:
+            return f"could not parse Parquet footer: {err}"
+
+        version = int(fm.get(_FM_VERSION, 0)) if fm.get(_FM_VERSION) is not None else 0
+        num_rows_raw = fm.get(_FM_NUM_ROWS)
+        num_rows = int(num_rows_raw) if num_rows_raw is not None else None
+
+        columns: list[str] = []
+        schema_types: list[str] = []
+        schema = fm.get(_FM_SCHEMA)
+        if isinstance(schema, list):
+            for element in schema:
+                if not isinstance(element, dict):
+                    continue
+                name = element.get(_SE_NAME)
+                num_children = element.get(_SE_NUM_CHILDREN)
+                # The first element is the root group; columns follow it.
+                # Skip root when it has children (it's not a leaf column).
+                if num_children:
+                    continue
+                if name is not None:
+                    columns.append(str(name))
+                type_id = element.get(_SE_TYPE)
+                if type_id is not None:
+                    schema_types.append(_PARQUET_TYPE.get(int(type_id), "UNKNOWN"))
+                else:
+                    schema_types.append("UNKNOWN")
+
+        row_groups = fm.get(_FM_ROW_GROUPS)
+        num_row_groups = len(row_groups) if isinstance(row_groups, list) else None
+
+        return version, num_rows, columns, schema_types, num_row_groups

--- a/tests/_parquet_fixtures.py
+++ b/tests/_parquet_fixtures.py
@@ -1,0 +1,176 @@
+"""Minimal, dependency-free Parquet fixture generator (test-only).
+
+Produces a valid Parquet file whose *footer* encodes a realistic
+FileMetaData (version, num_rows, schema, one row group) so the
+ParquetInspector's Thrift-Compact footer parser is exercised against a
+real footer shape. No data pages are written — the inspector only reads
+metadata, so a footer-only file is sufficient and keeps the fixture tiny.
+
+This is deliberately test-only: production never writes Parquet.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+# Thrift Compact wire type ids (mirror of src/hotmem/inspectors/_thrift.py).
+_CT_STOP = 0x00
+_CT_BOOL_TRUE = 0x01
+_CT_I16 = 0x04
+_CT_I32 = 0x05
+_CT_I64 = 0x06
+_CT_BINARY = 0x08
+_CT_LIST = 0x09
+_CT_STRUCT = 0x0C
+
+_PARQUET_MAGIC = b"PAR1"
+
+
+def _zigzag(n: int) -> int:
+    return (n << 1) ^ (n >> 63)
+
+
+def _varint(n: int) -> bytes:
+    n = _zigzag(n)
+    out = bytearray()
+    while True:
+        b = n & 0x7F
+        n >>= 7
+        if n:
+            out.append(b | 0x80)
+        else:
+            out.append(b)
+            break
+    return bytes(out)
+
+
+class _CompactWriter:
+    def __init__(self) -> None:
+        self.buf = bytearray()
+
+    def byte(self, b: int) -> None:
+        self.buf.append(b & 0xFF)
+
+    def varint(self, n: int) -> None:
+        self.buf += _varint(n)
+
+    def field_header(self, field_id: int, wire_type: int, last_field: int) -> int:
+        delta = field_id - last_field
+        if 0 < delta <= 15:
+            self.byte((delta << 4) | wire_type)
+        else:
+            self.byte(wire_type)  # delta == 0 means explicit field id follows
+            self.varint(field_id)
+        return field_id
+
+    def write_i32(self, field_id: int, value: int, last: int) -> int:
+        lf = self.field_header(field_id, _CT_I32, last)
+        self.varint(value)
+        return lf
+
+    def write_i64(self, field_id: int, value: int, last: int) -> int:
+        lf = self.field_header(field_id, _CT_I64, last)
+        self.varint(value)
+        return lf
+
+    def write_string(self, field_id: int, value: str, last: int) -> int:
+        lf = self.field_header(field_id, _CT_BINARY, last)
+        data = value.encode("utf-8")
+        self.varint(len(data))
+        self.buf += data
+        return lf
+
+    def write_struct_field(self, field_id: int, last: int) -> int:
+        return self.field_header(field_id, _CT_STRUCT, last)
+
+    def write_list_header(self, field_id: int, size: int, element_type: int, last: int) -> int:
+        lf = self.field_header(field_id, _CT_LIST, last)
+        if size < 15:
+            self.byte((size << 4) | element_type)
+        else:
+            self.byte(0xF0 | element_type)
+            self.varint(size)
+        return lf
+
+    def stop(self) -> None:
+        self.byte(_CT_STOP)
+
+
+def _schema_element(w: _CompactWriter, name: str, type_id: int, num_children: int | None) -> None:
+    """Write one SchemaElement struct (ascending field ids, then STOP)."""
+    last = 0
+    if type_id is not None:
+        last = w.write_i32(1, type_id, last)  # Type
+    last = w.write_string(4, name, last)  # name (required)
+    if num_children is not None:
+        last = w.write_i32(5, num_children, last)  # num_children
+    w.stop()
+
+
+def _row_group(w: _CompactWriter, num_rows: int, total_byte_size: int, num_columns: int) -> None:
+    """Write one RowGroup struct (parquet.thrift field ids)."""
+    last = 0
+    # field 1: list<ColumnChunk> columns
+    last = w.write_list_header(1, num_columns, _CT_STRUCT, last)
+    for _ in range(num_columns):
+        # ColumnChunk: field 1 file_offset (i64), field 2 meta (ColumnMetaData)
+        cc_last = 0
+        cc_last = w.write_i64(1, 0, cc_last)  # file_offset
+        w.write_struct_field(2, cc_last)  # ColumnMetaData struct
+        cm_last = 0
+        cm_last = w.write_i32(1, 6, cm_last)  # type = BYTE_ARRAY
+        cm_last = w.write_list_header(2, 0, _CT_BINARY, cm_last)  # encodings (empty)
+        cm_last = w.write_list_header(3, 0, _CT_BINARY, cm_last)  # path_in_schema (empty)
+        cm_last = w.write_i32(4, 1, cm_last)  # codec = UNCOMPRESSED (i32)
+        cm_last = w.write_i64(5, 0, cm_last)  # num_values (i64)
+        cm_last = w.write_i64(6, 0, cm_last)  # total_uncompressed_size (i64)
+        cm_last = w.write_i64(7, 0, cm_last)  # total_compressed_size (i64)
+        cm_last = w.write_i64(9, 4, cm_last)  # data_page_offset (i64)
+        w.stop()  # end ColumnMetaData
+        w.stop()  # end ColumnChunk
+    last = w.write_i64(2, total_byte_size, last)  # total_byte_size (i64)
+    last = w.write_i64(3, num_rows, last)  # num_rows (i64)
+    w.stop()
+
+
+def write_parquet_fixture(
+    path: Path,
+    *,
+    num_rows: int = 3,
+    columns: list[tuple[str, int]] | None = None,
+) -> Path:
+    """Write a minimal valid Parquet file (footer-only) to ``path``.
+
+    ``columns`` is a list of (name, parquet_type_id) pairs. The file has one
+    row group. No data pages are written; the inspector only reads metadata.
+    """
+    if columns is None:
+        columns = [("id", 1), ("name", 6)]  # INT32, BYTE_ARRAY
+
+    w = _CompactWriter()
+    last = 0
+    last = w.write_i32(1, 1, last)  # version = 1
+
+    # schema: root element + one element per column.
+    last = w.write_list_header(2, len(columns) + 1, _CT_STRUCT, last)
+    _schema_element(w, "root", None, len(columns))  # root, num_children = n
+    for name, type_id in columns:
+        _schema_element(w, name, type_id, None)
+
+    last = w.write_i64(3, num_rows, last)  # num_rows
+
+    # row_groups: one row group with len(columns) ColumnChunks.
+    last = w.write_list_header(4, 1, _CT_STRUCT, last)
+    _row_group(w, num_rows=num_rows, total_byte_size=0, num_columns=len(columns))
+
+    w.stop()  # end FileMetaData
+
+    footer = bytes(w.buf)
+    out = bytearray()
+    out += _PARQUET_MAGIC
+    out += footer
+    out += struct.pack("<I", len(footer))
+    out += _PARQUET_MAGIC
+    path.write_bytes(bytes(out))
+    return path

--- a/tests/golden/__init__.py
+++ b/tests/golden/__init__.py
@@ -1,0 +1,1 @@
+"""Golden tests package for issue #54."""

--- a/tests/golden/conftest.py
+++ b/tests/golden/conftest.py
@@ -1,0 +1,109 @@
+"""Compatibility golden tests for HotMem's file-native evolution (issue #54).
+
+Purpose:
+    Make the non-breaking contract from docs/okf/file-aware-architecture.md
+    executable. These tests lock down the *current* public behavior of the API,
+    swap files, Python client, and MCP server so that file/bundle/snapshot
+    work landing in #38-#43 cannot silently drift the existing surface.
+
+Design:
+    - Volatile values (uuids, hashes, timestamps, floats, db paths) are masked
+      to typed sentinels so snapshots stay deterministic across runs while
+      their *types* remain locked.
+    - Golden expected shapes live under ``fixtures/`` as JSON and are loaded
+      once per session.
+    - Tests assert exact key sets and masked shapes, not free-form equality,
+      so a new optional field added by a future ticket fails *here* first and
+      forces an intentional update to the golden contract.
+
+Extension:
+    When a vNext ticket intentionally extends a public shape, update the
+    corresponding fixture in the same PR and add an additive-proof case to
+    test_golden_additive.py.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hotmem.server import create_app
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> Any:
+    return json.loads((FIXTURES / name).read_text())
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    """A TestClient against a fresh temp DB — the golden baseline surface."""
+    app = create_app(db_path=tmp_path / "golden.sqlite")
+    with TestClient(app) as c:
+        yield c
+
+
+def mask(value: Any) -> Any:
+    """Mask volatile values to typed sentinels, preserving structure/types.
+
+    Recursively walks dicts/lists. Scalars become one of:
+      "<int>", "<float>", "<str>", "<bool>", "<uuid>", "<hash>", "<ts>",
+      "<path>", "<null>".
+    Keys are always preserved (key drift is the real signal we want).
+    """
+    if isinstance(value, dict):
+        return {k: mask(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [mask(v) for v in value]
+    if value is None:
+        return "<null>"
+    if isinstance(value, bool):  # before int — bool is an int subclass
+        return "<bool>"
+    if isinstance(value, int):
+        return "<int>"
+    if isinstance(value, float):
+        return "<float>"
+    s = str(value)
+    if _looks_like_uuid(s):
+        return "<uuid>"
+    if _looks_like_hash(s):
+        return "<hash>"
+    if _looks_like_ts(s):
+        return "<ts>"
+    if _looks_like_path(s):
+        return "<path>"
+    return "<str>"
+
+
+_UUID_RE = __import__("re").compile(r"^[0-9a-f]{32}$")
+
+
+def _looks_like_uuid(s: str) -> bool:
+    return bool(_UUID_RE.match(s))
+
+
+def _looks_like_hash(s: str) -> bool:
+    return len(s) == 64 and all(c in "0123456789abcdef" for c in s)
+
+
+def _looks_like_ts(s: str) -> bool:
+    # ISO-8601 UTC created_at, e.g. 2026-07-06T16:36:33Z
+    return len(s) >= 8 and s[:4].isdigit() and "T" in s and s.endswith("Z")
+
+
+def _looks_like_path(s: str) -> bool:
+    return ("/" in s or "\\" in s) and s.endswith((".sqlite", ".jsonl", ".db"))
+
+
+def assert_keys_exact(actual: dict, expected_keys: set[str], where: str) -> None:
+    """Assert the dict has exactly ``expected_keys`` (no more, no fewer)."""
+    actual_keys = set(actual)
+    assert actual_keys == expected_keys, (
+        f"{where}: key drift. expected {sorted(expected_keys)}, "
+        f"got {sorted(actual_keys)}"
+    )

--- a/tests/golden/conftest.py
+++ b/tests/golden/conftest.py
@@ -104,6 +104,5 @@ def assert_keys_exact(actual: dict, expected_keys: set[str], where: str) -> None
     """Assert the dict has exactly ``expected_keys`` (no more, no fewer)."""
     actual_keys = set(actual)
     assert actual_keys == expected_keys, (
-        f"{where}: key drift. expected {sorted(expected_keys)}, "
-        f"got {sorted(actual_keys)}"
+        f"{where}: key drift. expected {sorted(expected_keys)}, got {sorted(actual_keys)}"
     )

--- a/tests/golden/fixtures/memories_expected.json
+++ b/tests/golden/fixtures/memories_expected.json
@@ -1,0 +1,9 @@
+{
+  "id": "<uuid>",
+  "identifier": "<str>",
+  "fact_text": "<str>",
+  "importance": "<float>",
+  "metadata_json": "<str>",
+  "source": "<str>",
+  "created_at": "<ts>"
+}

--- a/tests/golden/fixtures/search_expected.json
+++ b/tests/golden/fixtures/search_expected.json
@@ -1,0 +1,8 @@
+{
+  "role": "system",
+  "content": "<str>",
+  "memory_id": "<uuid>",
+  "identifier": "<str>",
+  "score": "<float>",
+  "created_at": "<ts>"
+}

--- a/tests/golden/test_golden_additive.py
+++ b/tests/golden/test_golden_additive.py
@@ -1,0 +1,120 @@
+"""Golden additive-contract proof — new optional fields must not change defaults.
+
+This is the executable form of #54's core requirement: "Explicit tests proving
+new optional fields do not change default behavior." It proves the file-native
+evolution is additive by comparing the observable behavior of a minimal legacy
+payload against an extended payload — across add, search, and list — and
+confirming they are indistinguishable modulo the intended differences.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hotmem.server import create_app
+
+from .conftest import mask
+
+
+def _fresh_client(tmp_path, name):
+    app = create_app(db_path=tmp_path / f"{name}.sqlite")
+    return TestClient(app)
+
+
+@pytest.fixture
+def client(tmp_path):
+    app = create_app(db_path=tmp_path / "add.sqlite")
+    with TestClient(app) as c:
+        yield c
+
+
+def test_minimal_and_extended_add_produce_identical_search_masks(tmp_path):
+    """A legacy {identifier, fact} add and a full add yield the same search shape.
+
+    Each scenario runs on an isolated DB so the comparison is between two
+    single-memory stores with the same fact — proving optional fields don't
+    change the observable search contract, only (intentionally) the score.
+    """
+    payload_fact = "duplicate invoice risk"
+    minimal_payload = {"identifier": "v", "fact": payload_fact}
+    extended_payload = {
+        "identifier": "v",
+        "fact": payload_fact,
+        "source": "erp",
+        "importance": 0.9,
+        "metadata": {"doc": "x"},
+        "ttl_seconds": 3600,
+    }
+
+    with _fresh_client(tmp_path, "min") as c:
+        c.post("/v1/add", json=minimal_payload)
+        minimal = c.post("/v1/search", json={"query": "duplicate invoice", "top_k": 5}).json()
+    with _fresh_client(tmp_path, "ext") as c:
+        c.post("/v1/add", json=extended_payload)
+        extended = c.post("/v1/search", json={"query": "duplicate invoice", "top_k": 5}).json()
+
+    assert mask(minimal) == mask(extended), (
+        "minimal and extended add payloads produce different search masks — "
+        "the file-native evolution is not purely additive"
+    )
+    assert mask(minimal) == {
+        "memories": [
+            {
+                "role": "<str>",
+                "content": "<str>",
+                "memory_id": "<uuid>",
+                "identifier": "<str>",
+                "score": "<float>",
+                "created_at": "<ts>",
+            },
+        ],
+        "count": "<int>",
+        "trace_ms": "<float>",
+    }
+
+
+def test_minimal_add_payload_round_trips_through_snapshot(client, tmp_path):
+    """A minimal-record snapshot round-trips back into a search hit (compat)."""
+    client.post("/v1/add", json={"identifier": "legacy", "fact": "old compatibility fact"})
+    swap = tmp_path / "compat.jsonl"
+    client.post("/v1/snapshot", json={"file": str(swap)})
+
+    # Fresh DB hydrates the legacy-shaped snapshot and finds the fact.
+    app2 = create_app(db_path=tmp_path / "compat2.sqlite")
+    with TestClient(app2) as c2:
+        loaded = c2.post("/v1/hydrate", json={"file": str(swap)}).json()
+        assert loaded["loaded"] == 1
+        search = c2.post("/v1/search", json={"query": "compatibility", "top_k": 1}).json()
+        assert search["count"] == 1
+        assert search["memories"][0]["content"] == "old compatibility fact"
+
+
+def test_omitted_optional_fields_use_documented_defaults(client):
+    """The defaults locked in db.py/db must be the defaults observed via API."""
+    client.post("/v1/add", json={"identifier": "d", "fact": "defaults fact"})
+    rows = client.get("/v1/memories", params={"identifier": "d"}).json()["memories"]
+    row = rows[0]
+    # importance default = 0.5, source default = "" (server sets nothing extra)
+    assert row["importance"] == 0.5
+    assert row["source"] == ""
+    assert row["metadata_json"] == "{}"
+
+
+def test_v2_provenance_columns_are_optional_and_defaulted(client, tmp_path):
+    """The file-native provenance columns exist but stay defaulted for legacy adds."""
+    client.post("/v1/add", json={"identifier": "p", "fact": "provenance fact"})
+    swap = tmp_path / "prov.jsonl"
+    client.post("/v1/snapshot", json={"file": str(swap)})
+
+    import json
+
+    first = json.loads(swap.read_text().splitlines()[0])
+    # File-native provenance fields are present but empty/default — i.e. additive.
+    assert first["source_uri"] == ""
+    assert first["source_format"] == ""
+    assert first["source_checksum"] == ""
+    assert first["byte_offset"] is None
+    assert first["byte_length"] is None
+    assert first["tier"] == "hot"
+    assert first["schema_version"] == 1

--- a/tests/golden/test_golden_api.py
+++ b/tests/golden/test_golden_api.py
@@ -18,9 +18,7 @@ def test_health_shape(client):
     resp = client.get("/v1/health")
     assert resp.status_code == 200
     body = resp.json()
-    assert_keys_exact(
-        body, {"status", "memory_count", "db_path", "uptime_s"}, "GET /v1/health"
-    )
+    assert_keys_exact(body, {"status", "memory_count", "db_path", "uptime_s"}, "GET /v1/health")
     assert mask(body) == {
         "status": "<str>",
         "memory_count": "<int>",

--- a/tests/golden/test_golden_api.py
+++ b/tests/golden/test_golden_api.py
@@ -1,0 +1,195 @@
+"""Golden API shape tests — lock down /v1 endpoint contracts (issue #54).
+
+These are *shape* contracts: exact top-level key sets and masked value types.
+A new field added to any response fails here first and must be an intentional
+golden-contract update (additive only — see test_golden_additive.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import _load_fixture, assert_keys_exact, mask
+
+# ── /v1/health ───────────────────────────────────────────────────────────────
+
+
+def test_health_shape(client):
+    resp = client.get("/v1/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert_keys_exact(
+        body, {"status", "memory_count", "db_path", "uptime_s"}, "GET /v1/health"
+    )
+    assert mask(body) == {
+        "status": "<str>",
+        "memory_count": "<int>",
+        "db_path": "<path>",
+        "uptime_s": "<float>",
+    }
+
+
+def test_health_trace_header(client):
+    """The X-HotMem-Trace-Id header is part of the public surface."""
+    resp = client.get("/v1/health")
+    assert "X-HotMem-Trace-Id" in resp.headers
+
+
+# ── /v1/add ──────────────────────────────────────────────────────────────────
+
+
+def test_add_minimal_payload_shape(client):
+    """The legacy {identifier, fact} add payload is the baseline contract."""
+    resp = client.post(
+        "/v1/add",
+        json={"identifier": "vendor_x", "fact": "Invoice total was $5000"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert_keys_exact(body, {"memory_id", "content_hash", "trace_ms"}, "POST /v1/add (minimal)")
+    assert mask(body) == {
+        "memory_id": "<uuid>",
+        "content_hash": "<hash>",
+        "trace_ms": "<float>",
+    }
+
+
+def test_add_extended_payload_shape(client):
+    """The full extended add payload returns the same response shape (additive)."""
+    resp = client.post(
+        "/v1/add",
+        json={
+            "identifier": "vendor_x",
+            "fact": "Invoice total was $5000",
+            "source": "erp",
+            "importance": 0.8,
+            "metadata": {"doc": "inv-9"},
+            "ttl_seconds": 3600,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert_keys_exact(body, {"memory_id", "content_hash", "trace_ms"}, "POST /v1/add (extended)")
+    assert mask(body) == {
+        "memory_id": "<uuid>",
+        "content_hash": "<hash>",
+        "trace_ms": "<float>",
+    }
+
+
+# ── /v1/search ───────────────────────────────────────────────────────────────
+
+
+def test_search_response_shape(client):
+    client.post("/v1/add", json={"identifier": "a", "fact": "duplicate invoice risk for vendor x"})
+    client.post("/v1/add", json={"identifier": "b", "fact": "payment terms are net 30"})
+
+    resp = client.post("/v1/search", json={"query": "duplicate invoice risk", "top_k": 2})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert_keys_exact(body, {"memories", "count", "trace_ms"}, "POST /v1/search")
+
+    assert body["count"] == len(body["memories"])
+    assert body["count"] <= 2
+    expected_msg = _load_fixture("search_expected.json")
+    for m in body["memories"]:
+        assert m["role"] == "system"  # role is a stable literal, part of the contract
+        masked = mask(m)
+        masked["role"] = m["role"]  # preserve the literal for the shape compare
+        assert masked == expected_msg, f"search message drift: {masked} != {expected_msg}"
+
+
+def test_search_message_object_keys_locked(client):
+    """The message-object key set is the part clients depend on most."""
+    client.post("/v1/add", json={"identifier": "a", "fact": "duplicate invoice risk"})
+    resp = client.post("/v1/search", json={"query": "invoice", "top_k": 1})
+    msg = resp.json()["memories"][0]
+    assert_keys_exact(
+        msg,
+        {"role", "content", "memory_id", "identifier", "score", "created_at"},
+        "search message object",
+    )
+    assert msg["role"] == "system"
+
+
+# ── /v1/memories ──────────────────────────────────────────────────────────────
+
+
+def test_memories_response_shape(client):
+    client.post("/v1/add", json={"identifier": "chat", "fact": "message 0"})
+    client.post("/v1/add", json={"identifier": "chat", "fact": "message 1"})
+
+    resp = client.get("/v1/memories", params={"identifier": "chat", "order": "asc"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert_keys_exact(body, {"memories", "count", "trace_ms"}, "GET /v1/memories")
+    assert body["count"] == len(body["memories"]) == 2
+
+    expected_row = _load_fixture("memories_expected.json")
+    for row in body["memories"]:
+        assert_keys_exact(
+            row,
+            set(expected_row.keys()),
+            "memories row",
+        )
+        assert mask(row) == expected_row, f"memories row drift: {mask(row)} != {expected_row}"
+
+
+def test_memories_rejects_bad_order(client):
+    resp = client.get("/v1/memories", params={"identifier": "x", "order": "sideways"})
+    assert resp.status_code == 400
+
+
+def test_memories_rejects_bad_limit(client):
+    resp = client.get("/v1/memories", params={"identifier": "x", "limit": 0})
+    assert resp.status_code == 400
+
+
+# ── /v1/hydrate ───────────────────────────────────────────────────────────────
+
+
+def test_hydrate_response_shape(client, tmp_path):
+    import json
+
+    swap = tmp_path / "h.jsonl"
+    swap.write_text(json.dumps({"identifier": "h", "fact_text": "hydrated fact"}) + "\n")
+
+    resp = client.post("/v1/hydrate", json={"file": str(swap)})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert_keys_exact(body, {"loaded", "skipped_dupes"}, "POST /v1/hydrate")
+    assert mask(body) == {"loaded": "<int>", "skipped_dupes": "<int>"}
+
+
+def test_hydrate_rejects_unsupported_extension(client, tmp_path):
+    """Unsupported swap formats must fail with a clear, stable error string."""
+    import json
+
+    swap = tmp_path / "h.txt"
+    swap.write_text(json.dumps({"identifier": "h", "fact_text": "x"}) + "\n")
+    resp = client.post("/v1/hydrate", json={"file": str(swap)})
+    assert resp.status_code == 400
+    assert "supported: .jsonl, .jsonl.gz" in resp.json()["detail"]
+
+
+# ── /v1/snapshot ──────────────────────────────────────────────────────────────
+
+
+def test_snapshot_response_shape(client, tmp_path):
+    client.post("/v1/add", json={"identifier": "s", "fact": "snapshot test fact"})
+    swap = str(tmp_path / "snap.jsonl")
+
+    resp = client.post("/v1/snapshot", json={"file": swap})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert_keys_exact(body, {"exported", "path"}, "POST /v1/snapshot")
+    assert mask(body) == {"exported": "<int>", "path": "<path>"}
+
+
+@pytest.mark.parametrize("missing", ["identifier", "fact"])
+def test_add_missing_required_field_rejected(client, missing):
+    """Pydantic validation rejects payloads missing schema-required fields."""
+    payload = {"identifier": "x", "fact": "y"}
+    payload.pop(missing)
+    resp = client.post("/v1/add", json=payload)
+    assert resp.status_code == 422

--- a/tests/golden/test_golden_client.py
+++ b/tests/golden/test_golden_client.py
@@ -118,7 +118,12 @@ def test_sync_client_emits_locked_payloads(tmp_path):
     ]
     # add payload — exact key set
     assert set(log[1][2]) == {
-        "identifier", "fact", "source", "importance", "metadata", "ttl_seconds",
+        "identifier",
+        "fact",
+        "source",
+        "importance",
+        "metadata",
+        "ttl_seconds",
     }
     assert log[1][2] == {
         "identifier": "vendor",
@@ -162,7 +167,12 @@ def test_async_client_emits_locked_payloads():
     ]
     # add payload omits ttl_seconds only when None — locked default shape
     assert set(log[1][2]) == {
-        "identifier", "fact", "source", "importance", "metadata", "ttl_seconds",
+        "identifier",
+        "fact",
+        "source",
+        "importance",
+        "metadata",
+        "ttl_seconds",
     }
 
 
@@ -198,8 +208,13 @@ def test_sync_client_return_shapes(tmp_path):
         assert_keys_exact(
             listed[0],
             {
-                "id", "identifier", "fact_text", "importance",
-                "metadata_json", "source", "created_at",
+                "id",
+                "identifier",
+                "fact_text",
+                "importance",
+                "metadata_json",
+                "source",
+                "created_at",
             },
             "client.list()[0]",
         )

--- a/tests/golden/test_golden_client.py
+++ b/tests/golden/test_golden_client.py
@@ -1,0 +1,223 @@
+"""Golden Python client surface tests — lock HotMemClient / AsyncHotMemClient.
+
+These lock the public method names and the request payloads they emit, plus
+the return shapes clients are expected to consume. A renamed/removed method or
+a changed payload fails here first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+
+import httpx
+from fastapi.testclient import TestClient
+
+from hotmem.client import AsyncHotMemClient, HotMemClient
+from hotmem.server import create_app
+
+from .conftest import assert_keys_exact
+
+SYNC_METHODS = {"health", "add", "search", "list", "hydrate", "snapshot", "close"}
+ASYNC_METHODS = {"health", "add", "search", "list", "hydrate", "snapshot", "close"}
+
+
+def test_sync_client_public_method_set_is_locked():
+    public = {
+        name
+        for name, _ in inspect.getmembers(HotMemClient, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    }
+    public |= {"__enter__", "__exit__"}  # context-manager protocol is public
+    assert public >= SYNC_METHODS, f"missing sync client methods: {SYNC_METHODS - public}"
+
+
+def test_async_client_public_method_set_is_locked():
+    public = {
+        name
+        for name, _ in inspect.getmembers(AsyncHotMemClient, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    }
+    public |= {"__aenter__", "__aexit__"}
+    assert public >= ASYNC_METHODS, f"missing async client methods: {ASYNC_METHODS - public}"
+
+
+# ── request payload contracts (via MockTransport) ─────────────────────────────
+
+
+def _capture() -> tuple[list[tuple[str, str, dict]], httpx.MockTransport]:
+    log: list[tuple[str, str, dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode()) if request.content else None
+        if payload is None:
+            log.append((request.method, request.url.path, None))
+        else:
+            log.append((request.method, request.url.path, payload))
+        match request.url.path:
+            case "/v1/health":
+                return httpx.Response(200, json={"status": "ok", "memory_count": 0})
+            case "/v1/add":
+                return httpx.Response(
+                    200,
+                    json={"memory_id": "m1", "content_hash": "h" * 64, "trace_ms": 1.0},
+                )
+            case "/v1/search":
+                return httpx.Response(
+                    200,
+                    json={
+                        "memories": [
+                            {
+                                "role": "system",
+                                "content": "fact",
+                                "memory_id": "m1",
+                                "identifier": "v",
+                                "score": 0.9,
+                                "created_at": "2026-07-06T00:00:00Z",
+                            }
+                        ],
+                        "count": 1,
+                        "trace_ms": 1.0,
+                    },
+                )
+            case "/v1/memories":
+                return httpx.Response(200, json={"memories": [], "count": 0, "trace_ms": 1.0})
+            case "/v1/hydrate":
+                return httpx.Response(200, json={"loaded": 1, "skipped_dupes": 0})
+            case "/v1/snapshot":
+                return httpx.Response(200, json={"exported": 1, "path": "swap.jsonl"})
+        return httpx.Response(404)
+
+    return log, httpx.MockTransport(handler)
+
+
+def test_sync_client_emits_locked_payloads(tmp_path):
+    """The exact request payloads the sync client sends are part of the contract."""
+    log, transport = _capture()
+    client = HotMemClient.__new__(HotMemClient)
+    client.base_url = "http://testserver"
+    client._client = httpx.Client(base_url=client.base_url, transport=transport, timeout=30.0)
+
+    client.health()
+    client.add("vendor", "fact", source="s", importance=0.7, metadata={"k": 1}, ttl_seconds=60)
+    client.search("fact", top_k=2, max_chars=100)
+    client.list("vendor", order="asc", limit=10)
+    client.hydrate("swap.jsonl")
+    client.snapshot("swap.jsonl")
+    client.close()
+
+    methods_paths = [(m, p) for m, p, _ in log]
+    assert methods_paths == [
+        ("GET", "/v1/health"),
+        ("POST", "/v1/add"),
+        ("POST", "/v1/search"),
+        ("GET", "/v1/memories"),
+        ("POST", "/v1/hydrate"),
+        ("POST", "/v1/snapshot"),
+    ]
+    # add payload — exact key set
+    assert set(log[1][2]) == {
+        "identifier", "fact", "source", "importance", "metadata", "ttl_seconds",
+    }
+    assert log[1][2] == {
+        "identifier": "vendor",
+        "fact": "fact",
+        "source": "s",
+        "importance": 0.7,
+        "metadata": {"k": 1},
+        "ttl_seconds": 60,
+    }
+    # search payload — only the keys that matter, no surprise fields
+    assert set(log[2][2]) == {"query", "top_k", "max_chars"}
+
+
+def test_async_client_emits_locked_payloads():
+    log, transport = _capture()
+
+    async def run():
+        client = AsyncHotMemClient.__new__(AsyncHotMemClient)
+        client.base_url = "http://testserver"
+        client._client = httpx.AsyncClient(
+            base_url=client.base_url, transport=transport, timeout=30.0
+        )
+        async with client as c:
+            await c.health()
+            await c.add("vendor", "fact", ttl_seconds=60)
+            await c.search("fact", top_k=2, max_chars=100)
+            await c.list("vendor")
+            await c.hydrate("swap.jsonl")
+            await c.snapshot("swap.jsonl")
+
+    asyncio.run(run())
+
+    methods_paths = [(m, p) for m, p, _ in log]
+    assert methods_paths == [
+        ("GET", "/v1/health"),
+        ("POST", "/v1/add"),
+        ("POST", "/v1/search"),
+        ("GET", "/v1/memories"),
+        ("POST", "/v1/hydrate"),
+        ("POST", "/v1/snapshot"),
+    ]
+    # add payload omits ttl_seconds only when None — locked default shape
+    assert set(log[1][2]) == {
+        "identifier", "fact", "source", "importance", "metadata", "ttl_seconds",
+    }
+
+
+# ── return-shape contracts (against a real TestClient server) ──────────────────
+
+
+def test_sync_client_return_shapes(tmp_path):
+    app = create_app(db_path=tmp_path / "c.sqlite")
+    with TestClient(app) as test_transport:
+        client = HotMemClient.__new__(HotMemClient)
+        client.base_url = "http://testserver"
+        client._client = test_transport
+
+        health = client.health()
+        assert_keys_exact(
+            health, {"status", "memory_count", "db_path", "uptime_s"}, "client.health()"
+        )
+
+        added = client.add("v", "invoice risk")
+        assert_keys_exact(added, {"memory_id", "content_hash", "trace_ms"}, "client.add()")
+
+        client.add("v", "payment terms")
+        results = client.search("invoice", top_k=1)
+        assert isinstance(results, list)
+        assert_keys_exact(
+            results[0],
+            {"role", "content", "memory_id", "identifier", "score", "created_at"},
+            "client.search()[0]",
+        )
+
+        listed = client.list("v", order="asc")
+        assert isinstance(listed, list)
+        assert_keys_exact(
+            listed[0],
+            {
+                "id", "identifier", "fact_text", "importance",
+                "metadata_json", "source", "created_at",
+            },
+            "client.list()[0]",
+        )
+
+        hydrated = client.hydrate()
+        assert_keys_exact(hydrated, {"loaded", "skipped_dupes"}, "client.hydrate()")
+
+        snap = client.snapshot()
+        assert_keys_exact(snap, {"exported", "path"}, "client.snapshot()")
+
+
+def test_sync_client_add_with_metadata_serializes_to_json_string():
+    """metadata dict must be JSON-serializable in the wire payload (not a string)."""
+    log, transport = _capture()
+    client = HotMemClient.__new__(HotMemClient)
+    client.base_url = "http://testserver"
+    client._client = httpx.Client(base_url=client.base_url, transport=transport, timeout=30.0)
+    client.add("v", "f", metadata={"k": [1, 2]})
+    assert log[0][2]["metadata"] == {"k": [1, 2]}
+    assert isinstance(log[0][2]["metadata"], dict)
+    client.close()

--- a/tests/golden/test_golden_mcp.py
+++ b/tests/golden/test_golden_mcp.py
@@ -63,8 +63,7 @@ def test_mcp_tool_required_fields_are_locked(tmp_path):
     for name, required in LOCKED_REQUIRED.items():
         schema = tools[name]["inputSchema"]
         assert schema.get("required", []) == required, (
-            f"MCP tool {name}: required drift. expected {required}, "
-            f"got {schema.get('required')}"
+            f"MCP tool {name}: required drift. expected {required}, got {schema.get('required')}"
         )
 
 

--- a/tests/golden/test_golden_mcp.py
+++ b/tests/golden/test_golden_mcp.py
@@ -1,0 +1,183 @@
+"""Golden MCP surface tests — lock tool names and inputSchema shapes (issue #54).
+
+MCP clients (Claude Desktop, Cursor, Warp) bind to tool names and schema
+``required`` arrays. Renaming a tool or dropping a required field is a silent
+breaking change. These tests make that contract executable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp", reason="requires the optional [mcp] extra")
+
+from mcp.types import ListToolsRequest  # noqa: E402
+
+from hotmem.db import MemoryDB  # noqa: E402
+from hotmem.mcp_server import _ServerState, create_server  # noqa: E402
+
+from .conftest import mask  # noqa: E402
+
+# Locked tool-name set. Adding a tool is allowed (and will fail this test,
+# forcing an intentional golden update); removing/renaming one is a break.
+LOCKED_TOOLS = {
+    "add_memory",
+    "search_memories",
+    "memory_health",
+    "snapshot",
+    "hydrate",
+}
+
+LOCKED_REQUIRED = {
+    "add_memory": ["identifier", "fact"],
+    "search_memories": ["query"],
+    "memory_health": [],
+    "snapshot": [],
+    "hydrate": [],
+}
+
+
+def _tools(db_path: Path) -> dict[str, dict]:
+    server = create_server(db_path)
+    result = asyncio.run(
+        server.request_handlers[ListToolsRequest](ListToolsRequest(method="tools/list"))
+    )
+    return {
+        t.name: {"inputSchema": t.inputSchema, "description": t.description}
+        for t in result.root.tools
+    }
+
+
+def test_mcp_tool_name_set_is_locked(tmp_path):
+    tools = _tools(tmp_path / "m.sqlite")
+    assert set(tools) == LOCKED_TOOLS
+
+
+def test_mcp_tool_required_fields_are_locked(tmp_path):
+    tools = _tools(tmp_path / "m.sqlite")
+    for name, required in LOCKED_REQUIRED.items():
+        schema = tools[name]["inputSchema"]
+        assert schema.get("required", []) == required, (
+            f"MCP tool {name}: required drift. expected {required}, "
+            f"got {schema.get('required')}"
+        )
+
+
+def test_mcp_tool_top_level_schema_keys_locked(tmp_path):
+    """Every tool's inputSchema is a JSON object; no surprise top-level keys."""
+    tools = _tools(tmp_path / "m.sqlite")
+    for name, spec in tools.items():
+        schema = spec["inputSchema"]
+        assert schema.get("type") == "object", f"{name} schema type != object"
+        assert "properties" in schema, f"{name} missing properties"
+        # `required` may be omitted when a tool has no required fields.
+        assert set(schema) <= {"type", "properties", "required"}, (
+            f"{name} has unexpected schema keys: {set(schema) - {'type', 'properties', 'required'}}"
+        )
+
+
+def test_mcp_add_memory_argument_shape_locked(tmp_path):
+    tools = _tools(tmp_path / "m.sqlite")
+    props = tools["add_memory"]["inputSchema"]["properties"]
+    assert set(props) == {"identifier", "fact", "importance", "ttl_seconds"}
+    assert props["identifier"] == {"type": "string"}
+    assert props["fact"] == {"type": "string"}
+    assert props["importance"] == {"type": "number", "minimum": 0.0, "maximum": 1.0}
+    assert props["ttl_seconds"] == {"type": "integer", "minimum": 1}
+
+
+def test_mcp_search_memory_argument_shape_locked(tmp_path):
+    tools = _tools(tmp_path / "m.sqlite")
+    props = tools["search_memories"]["inputSchema"]["properties"]
+    assert set(props) == {"query", "top_k", "max_chars"}
+    assert props["query"] == {"type": "string"}
+    assert props["top_k"] == {"type": "integer", "minimum": 1, "maximum": 100}
+    assert props["max_chars"] == {"type": "integer", "minimum": 1}
+
+
+# ── payload (CallToolResult) shape contracts ──────────────────────────────────
+
+
+def _state(tmp_path: Path) -> _ServerState:
+    db = MemoryDB(tmp_path / "s.sqlite")
+    st = _ServerState()
+    st.db = db
+    st.db_path = str(tmp_path / "s.sqlite")
+    st.swap_path = None
+    st.start_time = time.time()
+    return st
+
+
+def _text(result) -> dict:
+    return json.loads(result.content[0].text)
+
+
+def test_mcp_add_memory_result_shape_locked(tmp_path):
+    from hotmem.mcp_server import _handle_add_memory
+
+    st = _state(tmp_path)
+    try:
+        payload = _text(_handle_add_memory(st, {"identifier": "v", "fact": "f"}))
+        assert set(payload) == {"memory_id", "content_hash", "trace_ms"}
+        assert mask(payload) == {
+            "memory_id": "<uuid>",
+            "content_hash": "<hash>",
+            "trace_ms": "<float>",
+        }
+    finally:
+        st.db.close()
+
+
+def test_mcp_search_result_shape_locked(tmp_path):
+    from hotmem.mcp_server import _handle_add_memory, _handle_search_memories
+
+    st = _state(tmp_path)
+    try:
+        _handle_add_memory(st, {"identifier": "a", "fact": "invoice risk"})
+        payload = _text(_handle_search_memories(st, {"query": "invoice", "top_k": 1}))
+        assert set(payload) == {"memories", "count", "trace_ms"}
+        assert payload["count"] == len(payload["memories"])
+        msg = payload["memories"][0]
+        assert set(msg) == {"role", "content", "memory_id", "identifier", "score", "created_at"}
+        assert msg["role"] == "system"
+    finally:
+        st.db.close()
+
+
+def test_mcp_health_result_shape_locked(tmp_path):
+    from hotmem.mcp_server import _handle_memory_health
+
+    st = _state(tmp_path)
+    try:
+        payload = _text(_handle_memory_health(st, {}))
+        assert set(payload) == {"status", "memory_count", "db_path", "uptime_s"}
+    finally:
+        st.db.close()
+
+
+def test_mcp_unknown_tool_is_error(tmp_path):
+    from mcp.types import CallToolRequest, CallToolRequestParams
+
+    import hotmem.mcp_server as mcp_server
+
+    db = MemoryDB(tmp_path / "u.sqlite")
+    mcp_server._state.db = db
+    mcp_server._state.db_path = str(tmp_path / "u.sqlite")
+    mcp_server._state.swap_path = None
+    mcp_server._state.start_time = time.time()
+    try:
+        server = create_server(str(tmp_path / "u.sqlite"))
+        req = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name="does_not_exist", arguments={}),
+        )
+        result = asyncio.run(server.request_handlers[CallToolRequest](req))
+        assert result.root.isError
+        assert "unknown tool" in json.loads(result.root.content[0].text)["error"]
+    finally:
+        db.close()

--- a/tests/golden/test_golden_swap.py
+++ b/tests/golden/test_golden_swap.py
@@ -1,0 +1,260 @@
+"""Golden swap-file compatibility tests — lock JSONL & JSONL.GZ round trips.
+
+Guards the compatibility promise in file-native-memory-practices.md §10:
+"Legacy .jsonl and .jsonl.gz remain readable. JSONL export remains available."
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+
+from hotmem.db import MemoryDB
+from hotmem.swap import hydrate, snapshot
+
+from .conftest import mask
+
+
+def _first_record_keys(path: Path) -> set[str]:
+    with open(path) as f:
+        first = f.readline().strip()
+    return set(json.loads(first))
+
+
+def _all_records(path: Path) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _all_records_gz(path: Path) -> list[dict]:
+    with gzip.open(path, "rt") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# ── JSONL round trip ──────────────────────────────────────────────────────────
+
+
+def test_jsonl_snapshot_record_key_set_is_locked(tmp_path: Path):
+    db = MemoryDB(tmp_path / "src.sqlite")
+    try:
+        db.insert(
+            id="a" * 32,
+            identifier="vendor_x",
+            fact_text="Invoice total was $5000",
+            embedding=b"\x00" * (32 * 4),
+            content_hash="c" * 64,
+        )
+        swap = tmp_path / "out.jsonl"
+        snapshot(db, swap)
+
+        keys = _first_record_keys(swap)
+        # The full extended-record key set — locked so a column rename/add is
+        # an intentional, additive change caught here.
+        assert keys == {
+            "id", "identifier", "fact_text", "embedding_dim", "embedding_model",
+            "source", "importance", "metadata_json", "content_hash", "ttl_seconds",
+            "created_at", "namespace", "tier", "memory_type", "source_uri",
+            "source_format", "source_checksum", "byte_offset", "byte_length",
+            "updated_at", "snapshot_id", "promotion_state", "promotion_candidate",
+            "parent_memory", "related_memories", "tags", "schema_version",
+            "embedding_b64",
+        }
+    finally:
+        db.close()
+
+
+def test_jsonl_snapshot_hydrate_round_trip_preserves_facts(tmp_path: Path):
+    """snapshot → (fresh DB) → hydrate → snapshot is fact-stable."""
+    src = MemoryDB(tmp_path / "src.sqlite")
+    swap1 = tmp_path / "a.jsonl"
+    try:
+        src.insert(
+            id="1" * 32,
+            identifier="u",
+            fact_text="first fact",
+            embedding=b"\x00" * (32 * 4),
+            content_hash="a" * 64,
+        )
+        src.insert(
+            id="2" * 32,
+            identifier="u",
+            fact_text="second fact",
+            embedding=b"\x00" * (32 * 4),
+            content_hash="b" * 64,
+        )
+        snapshot(src, swap1)
+        facts_before = sorted(r["fact_text"] for r in _all_records(swap1))
+    finally:
+        src.close()
+
+    dst = MemoryDB(tmp_path / "dst.sqlite")
+    swap2 = tmp_path / "b.jsonl"
+    try:
+        result = hydrate(dst, swap1)
+        assert result.loaded == 2
+        assert result.skipped_dupes == 0
+        snapshot(dst, swap2)
+        facts_after = sorted(r["fact_text"] for r in _all_records(swap2))
+    finally:
+        dst.close()
+
+    assert facts_before == facts_after == ["first fact", "second fact"]
+
+
+def test_jsonl_hydrate_dedup_is_stable(tmp_path: Path):
+    """Re-hydrating the same swap into the same DB skips all duplicates."""
+    db = MemoryDB(tmp_path / "d.sqlite")
+    swap = tmp_path / "s.jsonl"
+    swap.write_text(
+        json.dumps({"identifier": "u", "fact_text": "stable fact", "content_hash": "h" * 64})
+        + "\n"
+    )
+    try:
+        first = hydrate(db, swap)
+        assert first.loaded == 1 and first.skipped_dupes == 0
+        second = hydrate(db, swap)
+        assert second.loaded == 0 and second.skipped_dupes == 1
+    finally:
+        db.close()
+
+
+def test_jsonl_hydrate_accepts_minimal_v01_record(tmp_path: Path):
+    """A v0.1-style record (only identifier + fact_text) still hydrates."""
+    db = MemoryDB(tmp_path / "v01.sqlite")
+    swap = tmp_path / "v01.jsonl"
+    swap.write_text(json.dumps({"identifier": "legacy", "fact_text": "old fact"}) + "\n")
+    try:
+        result = hydrate(db, swap)
+        assert result.loaded == 1
+        rows = db.all_rows()
+        assert rows[0]["identifier"] == "legacy"
+        assert rows[0]["fact_text"] == "old fact"
+        # Defaults are applied, not required in the payload:
+        assert rows[0]["importance"] == 0.5
+        assert rows[0]["source"] == "swap"
+    finally:
+        db.close()
+
+
+# ── JSONL.GZ round trip ───────────────────────────────────────────────────────
+
+
+def test_jsonl_gz_snapshot_hydrate_round_trip(tmp_path: Path):
+    db = MemoryDB(tmp_path / "gz.sqlite")
+    swap = tmp_path / "out.jsonl.gz"
+    try:
+        db.insert(
+            id="9" * 32,
+            identifier="g",
+            fact_text="compressed fact",
+            embedding=b"\x00" * (32 * 4),
+            content_hash="d" * 64,
+        )
+        result = snapshot(db, swap)
+        assert result.exported == 1
+        assert swap.exists()
+
+        records = _all_records_gz(swap)
+        assert len(records) == 1
+        assert records[0]["fact_text"] == "compressed fact"
+        assert "embedding_b64" in records[0]
+    finally:
+        db.close()
+
+    dst = MemoryDB(tmp_path / "gz_dst.sqlite")
+    try:
+        loaded = hydrate(dst, swap)
+        assert loaded.loaded == 1
+        assert dst.count() == 1
+    finally:
+        dst.close()
+
+
+def test_jsonl_gz_record_key_set_matches_plain_jsonl(tmp_path: Path):
+    """The .gz variant must serialize the same record key set as plain .jsonl."""
+    db = MemoryDB(tmp_path / "k.sqlite")
+    try:
+        db.insert(
+            id="1" * 32,
+            identifier="u",
+            fact_text="x",
+            embedding=b"\x00" * (32 * 4),
+            content_hash="a" * 64,
+        )
+        gz = tmp_path / "g.jsonl.gz"
+        plain = tmp_path / "g.jsonl"
+        snapshot(db, gz)
+        snapshot(db, plain)
+        gz_keys = set(_all_records_gz(gz)[0])
+        plain_keys = set(_all_records(plain)[0])
+        assert gz_keys == plain_keys
+    finally:
+        db.close()
+
+
+def test_jsonl_gz_malformed_raises_clear_error(tmp_path: Path):
+    """A corrupt .gz must surface a clear ValueError, not a silent skip."""
+    bad = tmp_path / "bad.jsonl.gz"
+    bad.write_bytes(b"not a gzip stream at all")
+    db = MemoryDB(tmp_path / "bad.sqlite")
+    try:
+        with pytest.raises(ValueError, match="malformed compressed swap file"):
+            hydrate(db, bad)
+    finally:
+        db.close()
+
+
+# ── SQLite fast-path round trip ───────────────────────────────────────────────
+
+
+def test_sqlite_hydrate_fast_path_preserves_facts(tmp_path: Path):
+    """The SQLite→SQLite import fast path reuses embeddings and preserves facts."""
+    src = MemoryDB(tmp_path / "src.sqlite")
+    try:
+        src.insert(
+            id="5" * 32,
+            identifier="fp",
+            fact_text="fast path fact",
+            embedding=b"\x0a" * (32 * 4),
+            content_hash="e" * 64,
+        )
+    finally:
+        src.close()
+
+    dst = MemoryDB(tmp_path / "dst.sqlite")
+    try:
+        result = hydrate(dst, tmp_path / "src.sqlite")
+        assert result.loaded == 1
+        rows = dst.all_rows()
+        assert rows[0]["fact_text"] == "fast path fact"
+    finally:
+        dst.close()
+
+
+# ── Additive: snapshot is JSON-parseable and types are stable ──────────────────
+
+
+def test_jsonl_snapshot_values_are_json_serializable_and_maskable(tmp_path: Path):
+    """Every snapshot record must round-trip through json without custom types."""
+    db = MemoryDB(tmp_path / "ser.sqlite")
+    swap = tmp_path / "ser.jsonl"
+    try:
+        db.insert(
+            id="7" * 32,
+            identifier="u",
+            fact_text="serializable",
+            embedding=b"\x00" * (32 * 4),
+            content_hash="f" * 64,
+            metadata_json='{"k": 1}',
+        )
+        snapshot(db, swap)
+        records = _all_records(swap)
+        masked = mask(records[0])
+        # The masked record must be a pure dict of sentinels — no raw bytes.
+        assert isinstance(masked, dict)
+        assert all(isinstance(v, str) for v in masked.values())
+    finally:
+        db.close()

--- a/tests/golden/test_golden_swap.py
+++ b/tests/golden/test_golden_swap.py
@@ -54,12 +54,33 @@ def test_jsonl_snapshot_record_key_set_is_locked(tmp_path: Path):
         # The full extended-record key set — locked so a column rename/add is
         # an intentional, additive change caught here.
         assert keys == {
-            "id", "identifier", "fact_text", "embedding_dim", "embedding_model",
-            "source", "importance", "metadata_json", "content_hash", "ttl_seconds",
-            "created_at", "namespace", "tier", "memory_type", "source_uri",
-            "source_format", "source_checksum", "byte_offset", "byte_length",
-            "updated_at", "snapshot_id", "promotion_state", "promotion_candidate",
-            "parent_memory", "related_memories", "tags", "schema_version",
+            "id",
+            "identifier",
+            "fact_text",
+            "embedding_dim",
+            "embedding_model",
+            "source",
+            "importance",
+            "metadata_json",
+            "content_hash",
+            "ttl_seconds",
+            "created_at",
+            "namespace",
+            "tier",
+            "memory_type",
+            "source_uri",
+            "source_format",
+            "source_checksum",
+            "byte_offset",
+            "byte_length",
+            "updated_at",
+            "snapshot_id",
+            "promotion_state",
+            "promotion_candidate",
+            "parent_memory",
+            "related_memories",
+            "tags",
+            "schema_version",
             "embedding_b64",
         }
     finally:
@@ -109,8 +130,7 @@ def test_jsonl_hydrate_dedup_is_stable(tmp_path: Path):
     db = MemoryDB(tmp_path / "d.sqlite")
     swap = tmp_path / "s.jsonl"
     swap.write_text(
-        json.dumps({"identifier": "u", "fact_text": "stable fact", "content_hash": "h" * 64})
-        + "\n"
+        json.dumps({"identifier": "u", "fact_text": "stable fact", "content_hash": "h" * 64}) + "\n"
     )
     try:
         first = hydrate(db, swap)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,6 +193,44 @@ def test_search_rejects_both_db_and_url(tmp_path: Path):
     assert "not both" in result.output.lower()
 
 
+# ── inspect ────────────────────────────────────────────────────────────
+
+
+def test_inspect_csv_json_output(tmp_path: Path):
+    path = tmp_path / "data.csv"
+    path.write_text("id,name\n1,alice\n2,bob\n")
+    result = CliRunner().invoke(main, ["inspect", str(path), "--json", "--count-rows"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["format"] == "csv"
+    assert data["columns"] == ["id", "name"]
+    assert data["row_count"] == 2
+    assert len(data["checksum"]) == 64
+
+
+def test_inspect_csv_plain_output(tmp_path: Path):
+    path = tmp_path / "data.csv"
+    path.write_text("id,name\n1,alice\n2,bob\n")
+    result = CliRunner().invoke(main, ["inspect", str(path), "--count-rows"])
+    assert result.exit_code == 0, result.output
+    assert "format=csv" in result.output
+    assert "columns: id, name" in result.output
+
+
+def test_inspect_unsupported_format_errors(tmp_path: Path):
+    path = tmp_path / "notes.txt"
+    path.write_text("just prose\n")
+    result = CliRunner().invoke(main, ["inspect", str(path)])
+    assert result.exit_code != 0
+    assert "EMOS" in result.output
+
+
+def test_inspect_remote_scheme_errors():
+    result = CliRunner().invoke(main, ["inspect", "s3://bucket/key.csv"])
+    assert result.exit_code != 0
+    assert "EMOS" in result.output
+
+
 # ── renderer delegation sanity ──────────────────────────────────────────
 
 

--- a/tests/test_inspectors.py
+++ b/tests/test_inspectors.py
@@ -69,6 +69,17 @@ def test_csv_file_uri_scheme(csv_file):
     assert insp.columns == ["id", "vendor", "amount"]
 
 
+def test_csv_handles_quoted_fields_with_embedded_newlines(tmp_path):
+    """A quoted CSV field containing a newline is one record, not two."""
+    path = tmp_path / "quoted.csv"
+    path.write_text('id,note\n1,"line one\nline two"\n2,simple\n')
+    insp = inspect_file(str(path), count_rows=True, sample_size=5)
+    assert insp.row_count == 2
+    assert insp.sample is not None and len(insp.sample) == 2
+    assert insp.sample[0] == {"id": "1", "note": "line one\nline two"}
+    assert insp.sample[1] == {"id": "2", "note": "simple"}
+
+
 # ── JSONL ────────────────────────────────────────────────────────────────────
 
 
@@ -172,6 +183,26 @@ def test_parquet_too_small_reports_unsupported_reason(tmp_path):
 
 
 # ── Registry + error paths ─────────────────────────────────────────────────────
+
+
+def test_thrift_read_list_with_15_plus_elements():
+    """Regression: read_list must not consume an extra element_type byte when
+    the list size is encoded as a varint (size >= 15). The element type lives
+    in the header byte's low nibble per the Compact Protocol spec."""
+    from hotmem.inspectors._thrift import _CT_I32, ThriftCompactReader
+
+    buf = bytearray()
+    buf.append(0xF0 | _CT_I32)  # size >= 15, element type = i32
+    # varint zigzag of 20
+    zz = (20 << 1) ^ (20 >> 63)
+    buf.append(zz & 0x7F)
+    # 20 i32 values of 0 (zigzag varint of 0 is a single 0 byte)
+    for _ in range(20):
+        buf.append(0)
+    reader = ThriftCompactReader(bytes(buf))
+    result = reader.read_list()
+    assert len(result) == 20
+    assert all(v == 0 for v in result)
 
 
 def test_inspect_file_unknown_format_raises(tmp_path):

--- a/tests/test_inspectors.py
+++ b/tests/test_inspectors.py
@@ -1,0 +1,214 @@
+"""Tests for hotmem.inspectors — CSV, JSONL, Parquet, registry, error paths.
+
+Covers issue #53 acceptance criteria:
+  - CSV fixture inspection returns stable metadata.
+  - JSONL fixture inspection streams/samples without full ingestion.
+  - Parquet-like fixture returns metadata only or an explicit unsupported error.
+  - Inspectors do not copy large file contents into SQLite.
+  - Existing hydrate/search behavior remains unchanged (guarded by golden tests).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from _parquet_fixtures import write_parquet_fixture
+
+from hotmem.inspectors import (
+    UnsupportedFormatError,
+    inspect_file,
+)
+from hotmem.storage import UnsupportedSchemeError
+
+# ── CSV ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def csv_file(tmp_path: Path) -> Path:
+    path = tmp_path / "invoices.csv"
+    path.write_text("id,vendor,amount\n1,Acme,5000\n2,Globex,3000\n3,Initech,7500\n")
+    return path
+
+
+def test_csv_inspection_returns_stable_metadata(csv_file):
+    insp = inspect_file(str(csv_file), count_rows=True, sample_size=2)
+    assert insp.format == "csv"
+    assert insp.uri == str(csv_file)
+    assert insp.columns == ["id", "vendor", "amount"]
+    assert insp.has_header is True
+    assert insp.delimiter == ","
+    assert insp.row_count == 3
+    assert insp.size == csv_file.stat().st_size
+    assert isinstance(insp.mtime, float)
+    assert len(insp.checksum) == 64
+    assert insp.sample is not None and len(insp.sample) == 2
+    assert insp.sample[0] == {"id": "1", "vendor": "Acme", "amount": "5000"}
+    assert insp.byte_ranges is not None and len(insp.byte_ranges) == 2
+
+
+def test_csv_row_count_optional_by_default(csv_file):
+    insp = inspect_file(str(csv_file))
+    assert insp.row_count is None
+    # Sample still works without counting (capped by available rows).
+    assert insp.sample is not None and len(insp.sample) == 3
+
+
+def test_csv_semicolon_delimiter(tmp_path):
+    path = tmp_path / "semi.csv"
+    path.write_text("a;b\n1;2\n3;4\n")
+    insp = inspect_file(str(path))
+    assert insp.delimiter == ";"
+    assert insp.columns == ["a", "b"]
+
+
+def test_csv_file_uri_scheme(csv_file):
+    insp = inspect_file(f"file://{csv_file}", count_rows=True)
+    assert insp.format == "csv"
+    assert insp.columns == ["id", "vendor", "amount"]
+
+
+# ── JSONL ────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def jsonl_file(tmp_path: Path) -> Path:
+    path = tmp_path / "records.jsonl"
+    lines = [
+        {"id": 1, "name": "alice"},
+        {"id": 2, "name": "bob"},
+        {"id": 3, "name": "carol"},
+        {"id": 4, "name": "dave"},
+        {"id": 5, "name": "eve"},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in lines) + "\n")
+    return path
+
+
+def test_jsonl_inspection_streams_and_samples(jsonl_file):
+    insp = inspect_file(str(jsonl_file), count_rows=True, sample_size=3)
+    assert insp.format == "jsonl"
+    assert insp.row_count == 5
+    assert insp.columns == ["id", "name"]
+    assert insp.sample is not None and len(insp.sample) == 3
+    assert insp.sample[0] == {"id": 1, "name": "alice"}
+    assert insp.byte_ranges is not None and len(insp.byte_ranges) == 3
+    # Byte ranges point at real offsets that round-trip back to the record.
+    off, length = insp.byte_ranges[0]
+    raw = jsonl_file.read_bytes()[off : off + length]
+    assert json.loads(raw.decode().strip()) == {"id": 1, "name": "alice"}
+    assert insp.unsupported_reason is None
+
+
+def test_jsonl_malformed_line_reported_not_raised(tmp_path):
+    path = tmp_path / "bad.jsonl"
+    path.write_text('{"id": 1}\n{not json}\n{"id": 3}\n')
+    insp = inspect_file(str(path), count_rows=True, sample_size=5)
+    assert insp.row_count == 3
+    assert insp.unsupported_reason is not None
+    assert "line 1" in insp.unsupported_reason
+
+
+def test_jsonl_handles_no_trailing_newline(tmp_path):
+    path = tmp_path / "notrail.jsonl"
+    path.write_text('{"a": 1}\n{"a": 2}')  # no trailing newline
+    insp = inspect_file(str(path), count_rows=True, sample_size=5)
+    assert insp.row_count == 2
+    assert insp.sample is not None and len(insp.sample) == 2
+
+
+def test_jsonl_sample_bounded_memory_does_not_load_full_file(tmp_path):
+    # A large-ish JSONL file: confirm inspection returns sane metadata without
+    # materializing every record into memory (sample_size is the cap).
+    path = tmp_path / "big.jsonl"
+    with open(path, "w") as f:
+        for i in range(1000):
+            f.write(json.dumps({"i": i, "blob": "x" * 200}) + "\n")
+    insp = inspect_file(str(path), count_rows=True, sample_size=4)
+    assert insp.row_count == 1000
+    assert insp.sample is not None and len(insp.sample) == 4
+
+
+# ── Parquet ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def parquet_file(tmp_path: Path) -> Path:
+    path = tmp_path / "data.parquet"
+    write_parquet_fixture(path, num_rows=3, columns=[("id", 1), ("name", 6)])
+    return path
+
+
+def test_parquet_inspection_returns_metadata_only(parquet_file):
+    insp = inspect_file(str(parquet_file))
+    assert insp.format == "parquet"
+    assert insp.row_count == 3
+    assert insp.num_row_groups == 1
+    assert insp.columns == ["id", "name"]
+    assert insp.schema_types == ["INT32", "BYTE_ARRAY"]
+    assert insp.metadata.get("version") == 1
+    assert insp.unsupported_reason is None
+    # Metadata-only: no sample rows are decoded (data pages are not read).
+    assert insp.sample is None
+
+
+def test_parquet_bad_magic_reports_unsupported_reason(tmp_path):
+    path = tmp_path / "broken.parquet"
+    path.write_bytes(
+        b"PAR1" + b"hello world this is not a parquet footer at all" + b"\x00\x00\x00\x00" + b"PAR1"
+    )
+    insp = inspect_file(str(path))
+    assert insp.format == "parquet"
+    assert insp.unsupported_reason is not None
+
+
+def test_parquet_too_small_reports_unsupported_reason(tmp_path):
+    path = tmp_path / "tiny.parquet"
+    path.write_bytes(b"PAR1")
+    insp = inspect_file(str(path))
+    assert insp.unsupported_reason is not None
+    assert "too small" in insp.unsupported_reason
+
+
+# ── Registry + error paths ─────────────────────────────────────────────────────
+
+
+def test_inspect_file_unknown_format_raises(tmp_path):
+    path = tmp_path / "data.xlsx"
+    path.write_bytes(b"PK\x03\x04not really")
+    with pytest.raises(UnsupportedFormatError, match="EMOS"):
+        inspect_file(str(path))
+
+
+def test_inspect_file_remote_scheme_raises(tmp_path):
+    with pytest.raises(UnsupportedSchemeError, match="EMOS"):
+        inspect_file("s3://bucket/key.csv")
+
+
+def test_inspect_file_unknown_txt_format(tmp_path):
+    path = tmp_path / "notes.txt"
+    path.write_text("just some prose\n")
+    with pytest.raises(UnsupportedFormatError):
+        inspect_file(str(path))
+
+
+def test_inspection_to_dict_is_json_serializable(csv_file):
+    import json
+
+    insp = inspect_file(str(csv_file), count_rows=True)
+    d = insp.to_dict()
+    json.dumps(d)  # must not raise
+    assert d["format"] == "csv"
+    assert d["row_count"] == 3
+
+
+# ── Non-regression: inspectors don't touch SQLite ─────────────────────────────
+
+
+def test_inspect_file_does_not_create_a_database(csv_file, tmp_path):
+    # Inspection is read-only and side-effect free: no .sqlite files appear.
+    before = {p for p in tmp_path.rglob("*") if p.suffix in (".sqlite", ".db")}
+    inspect_file(str(csv_file), count_rows=True)
+    after = {p for p in tmp_path.rglob("*") if p.suffix in (".sqlite", ".db")}
+    assert before == after


### PR DESCRIPTION
## Summary

Lands **#54 (compatibility golden tests, P0)** and **#53 (lightweight file inspectors, M5)** in the recommended order from `docs/okf/file-native-memory-practices.md` §13 — golden tests first to lock the contract, then inspectors added behind it. Design notes in `PLAN.md`.

This makes the non-breaking contract **executable** and gives HotMem real file-native provenance for large local files — with **zero new runtime dependencies**.

---

## Issue #54 — Compatibility golden tests (P0, M1)

Makes the compatibility promise in `file-aware-architecture.md` §5 executable *before* the broader vNext work (#38–#43) lands.

**`tests/golden/`** with a deterministic masking harness (`conftest.py`) that locks **exact key sets + value types** while masking volatile uuids/hashes/timestamps to typed sentinels (`<uuid>`, `<hash>`, `<ts>`, `<float>`, …) so snapshots stay deterministic across runs.

| Test file | What it locks |
| --- | --- |
| `test_golden_api.py` | `/v1/health`, `/v1/add` (minimal + extended), `/v1/search` message-object shape (vs `fixtures/search_expected.json`), `/v1/memories`, `/v1/hydrate`, `/v1/snapshot`, validation rejection |
| `test_golden_swap.py` | JSONL + JSONL.GZ snapshot→hydrate→snapshot round trips, record key sets, dedup stability, v0.1 minimal-record compatibility, SQLite fast-path, corrupt-`.gz` clear error |
| `test_golden_client.py` | `HotMemClient`/`AsyncHotMemClient` method sets, exact wire payloads (via `MockTransport`), return shapes |
| `test_golden_mcp.py` | MCP tool-name set (frozen), each tool's `inputSchema` (`required` + property shapes), result payload shapes |
| `test_golden_additive.py` | Minimal vs extended add produce identical masked search shapes; legacy snapshot round-trips; defaults honored; v2 provenance columns stay defaulted for legacy adds |

A future ticket that adds a field to a public shape **fails here first** and forces an intentional golden-contract update — that is the entire point.

---

## Issue #53 — Lightweight file inspectors (M5)

Read-only, metadata-only inspectors for CSV, JSONL, and Parquet that reference large files (URI + size + checksum + byte ranges) **without copying contents into SQLite** and **without becoming a query engine** — per the "HotMem owns vs EMOS owns" boundary in `file-aware-architecture.md` §4.

`src/hotmem/inspectors/`:

| Module | Approach | Memory |
| --- | --- | --- |
| `csv_inspector.py` | `csv.Sniffer` over a bounded head buffer for delimiter + header detection; optional row count via streaming `\n` scan; bounded sample with byte-range provenance | O(head buffer) |
| `jsonl_inspector.py` | Newline counting in fixed 1 MiB chunks; seek-style sampling with byte ranges; malformed lines reported via `unsupported_reason` not raised | O(1) regardless of file size |
| `parquet_inspector.py` + `_thrift.py` | Validate `PAR1` magic; read footer tail; parse Thrift Compact `FileMetaData` → num_rows, schema (column names + physical types), row_group count. **No data-page decode, no query engine, no pyarrow.** | O(footer) |

**The dependency-free Parquet bet** — `parquet_inspector.py` ships a minimal Thrift Compact Protocol reader (`_thrift.py`) that decodes only the footer metadata. This is the disruptive-in-scope choice: production-grade Parquet provenance with **zero new deps**, staying inside the "no analytical engine" boundary. Malformed/hostile footers set `unsupported_reason` rather than raising, so a bad file becomes provenance, not an outage.

`FileInspection` (frozen dataclass) is designed so a future file-backed memory (#38) can store it directly: URI, size, mtime, checksum, columns, row_count, sample, byte_ranges, plus format-specific extras.

Registry (`__init__.py`) reuses `storage.get_adapter` so remote schemes (s3://, hdfs://, …) fail fast with the existing `UnsupportedSchemeError` (EMOS boundary) before any inspector runs; unknown formats raise the symmetric `UnsupportedFormatError`.

### CLI

Additive, local-only `hotmem inspect <uri> [--count-rows] [--sample N] [--json]` — mirrors the `search --json` convention. HTTP/MCP endpoints are deliberately deferred to #43 to keep the compatibility surface #54 just locked.

---

## Dependencies / sequencing

- **Depends on**: #35, #36, #37 (closed foundation: architecture, extended record, storage adapter).
- **Enables**: #38 (file-backed memories — `FileInspection` + byte_ranges feed directly into file-pointer hydration), #43 (API extensions can expose `inspect_file` over HTTP/MCP).
- **Does not touch**: #39 (snapshot dir), #40 (hydration profiles), #41 (event log), #42 (promotion).
- **No new runtime deps**; `[dev]` unchanged. Pure stdlib, py3.11–3.14 unaffected.

---

## Verification

- `uv run pytest -q` → **212 passed** (150 baseline + 62 new) in 1.2s
- `uv run ruff check src tests` → clean
- `hotmem inspect --json` spot-checked on CSV/JSONL/Parquet fixtures, unsupported `.txt`, and `s3://` — all behave per contract

Acceptance criteria from both issues are met:
- ✅ CSV fixture inspection returns stable metadata
- ✅ JSONL fixture streams/samples without full ingestion
- ✅ Parquet fixture returns metadata only or an explicit unsupported error
- ✅ Inspectors do not copy large file contents into SQLite
- ✅ Existing hydrate/search behavior remains unchanged (guarded by golden tests)
- ✅ Existing `identifier`/`fact` add payloads still pass
- ✅ Existing `/v1/search` message object shape is locked
- ✅ Existing JSONL/GZ hydrate and snapshot round trips are locked
- ✅ Existing Python client methods remain compatible
- ✅ Existing MCP tool names and schemas remain compatible
- ✅ Tests are easy to extend from each vNext implementation ticket

Closes #53, closes #54
