### PR TITLE
feat: hydration profiles — agent/compact/audit/full #40

### DIFF
--- a/src/hotmem/profiles.py
+++ b/src/hotmem/profiles.py
@@ -1,0 +1,266 @@
+"""HotMem hydration profiles — profile-aware content and provenance retrieval.
+
+Purpose:
+     Allow consumers to ask for different levels of memory content and
+     provenance without changing existing hydrate defaults. Profiles are
+     additive request parameters; the default hydrate behavior is unchanged.
+
+Profiles:
+     agent:  concise content (fact_summary or truncated fact_text), no file reads.
+     compact: smallest representation — metadata only, no content, no file reads.
+     audit:   content + provenance, checksums, source references, warnings.
+     full:    maximum detail — inline content, file references, diagnostics.
+
+Rules:
+     - ``compact`` and ``agent`` never call ``adapter.read_range()``.
+     - ``audit`` and ``full`` may read file-backed content (lazy, on demand).
+     - Missing backing files surface as provenance errors (audit/full) or
+       warnings (agent/compact).
+     - Default hydrate (no profile) returns raw bytes — unchanged.
+
+Interface:
+     HydrationProfile = Literal["agent", "compact", "audit", "full"]
+     ProfiledHydration (dataclass): memory_id, identifier, memory_type, content,
+         verified, source_uri, byte_offset, byte_length, source_checksum,
+         fact_summary, warnings, profile
+     hydrate_with_profile(db, memory_id, *, profile="agent", base_dir=None,
+         verify=True) -> ProfiledHydration
+
+Deps: hotmem.db, hotmem.memory, hotmem.provenance, hotmem.storage, hotmem.trace
+Extension: add custom profiles or profile-specific transformations here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from hotmem.db import MemoryDB
+from hotmem.memory import hydrate_memory_detailed
+from hotmem.provenance import BackingFileMissingError, ProvenanceError
+from hotmem.storage import get_adapter
+from hotmem.trace import Timer, get_tracer
+
+_trace = get_tracer("profiles")
+
+HydrationProfile = Literal["agent", "compact", "audit", "full"]
+
+# Maximum content length for the "agent" profile (truncates large inline text).
+AGENT_MAX_CONTENT = 4096
+
+
+@dataclass
+class ProfiledHydration:
+    """Result of profile-aware hydration. Fields vary by profile.
+
+    - ``compact``: metadata only (content=None, no file reads).
+    - ``agent``: concise content (fact_summary or truncated fact_text).
+    - ``audit``: content + provenance + verification state.
+    - ``full``: everything — content, provenance, diagnostics, warnings.
+    """
+
+    memory_id: str
+    identifier: str
+    memory_type: str
+    profile: str
+    content: bytes | None = None
+    verified: bool = False
+    source_uri: str | None = None
+    byte_offset: int = 0
+    byte_length: int = 0
+    source_checksum: str | None = None
+    source_format: str | None = None
+    fact_summary: str | None = None
+    fact_text: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    exists: bool | None = None  # whether the backing file currently exists
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable dict. ``content`` is base64-encoded if present."""
+        import base64
+
+        d: dict[str, Any] = {
+            "memory_id": self.memory_id,
+            "identifier": self.identifier,
+            "memory_type": self.memory_type,
+            "profile": self.profile,
+            "verified": self.verified,
+        }
+        if self.content is not None:
+            d["content"] = base64.b64encode(self.content).decode("ascii")
+            d["content_encoding"] = "base64"
+        if self.source_uri is not None:
+            d["source_uri"] = self.source_uri
+        if self.byte_offset:
+            d["byte_offset"] = self.byte_offset
+        if self.byte_length:
+            d["byte_length"] = self.byte_length
+        if self.source_checksum:
+            d["source_checksum"] = self.source_checksum
+        if self.source_format:
+            d["source_format"] = self.source_format
+        if self.fact_summary:
+            d["fact_summary"] = self.fact_summary
+        if self.fact_text:
+            d["fact_text"] = self.fact_text
+        if self.warnings:
+            d["warnings"] = self.warnings
+        if self.exists is not None:
+            d["exists"] = self.exists
+        return d
+
+
+def hydrate_with_profile(
+    db: MemoryDB,
+    memory_id: str,
+    *,
+    profile: HydrationProfile = "agent",
+    base_dir: str | None = None,
+    verify: bool = True,
+) -> ProfiledHydration:
+    """Hydrate a memory with a profile-aware response shape.
+
+    ``compact`` and ``agent`` perform zero file reads. ``audit`` and ``full``
+    may read file-backed content (lazy, on demand). The default hydrate path
+    (no profile) is unchanged — this function is only called when a profile
+    is explicitly requested.
+    """
+    record = db.get_memory(memory_id)
+    if record is None:
+        raise KeyError(f"memory not found: {memory_id}")
+
+    with Timer() as t:
+        if profile == "compact":
+            result = _hydrate_compact(record)
+        elif profile == "agent":
+            result = _hydrate_agent(record, base_dir)
+        elif profile == "audit":
+            result = _hydrate_audit(db, record, base_dir, verify)
+        elif profile == "full":
+            result = _hydrate_full(db, record, base_dir, verify)
+        else:
+            raise ValueError(f"unknown profile: {profile!r}")
+
+    _trace.info(
+        "hydrate_profile",
+        f"hydrated {memory_id[:8]}… with profile={profile}",
+        detail={
+            "profile": profile,
+            "memory_type": record["memory_type"],
+            "ms": round(t.ms, 2),
+        },
+    )
+    return result
+
+
+def _hydrate_compact(record: dict[str, Any]) -> ProfiledHydration:
+    """Metadata only — no content, no file reads."""
+    warnings: list[str] = []
+    exists = None
+
+    if record["memory_type"] == "file" and record.get("source_uri"):
+        # Check if backing file exists (stat only, no read).
+        try:
+            adapter = get_adapter(record["source_uri"])
+            exists = adapter.exists(record["source_uri"])
+            if not exists:
+                warnings.append(f"backing file missing: {record['source_uri']}")
+        except Exception:
+            warnings.append(f"cannot check backing file: {record['source_uri']}")
+
+    return ProfiledHydration(
+        memory_id=record["id"],
+        identifier=record["identifier"],
+        memory_type=record["memory_type"],
+        profile="compact",
+        source_uri=record.get("source_uri") or None,
+        byte_offset=record.get("byte_offset") or 0,
+        byte_length=record.get("byte_length") or 0,
+        source_checksum=record.get("source_checksum") or None,
+        source_format=record.get("source_format") or None,
+        fact_summary=record.get("fact_summary"),
+        warnings=warnings,
+        exists=exists,
+    )
+
+
+def _hydrate_agent(record: dict[str, Any], base_dir: str | None) -> ProfiledHydration:
+    """Concise content — fact_summary or truncated fact_text. No file reads."""
+    compact = _hydrate_compact(record)
+
+    # For inline memories: use fact_text (truncated).
+    if record["memory_type"] != "file":
+        fact = record.get("fact_text") or ""
+        if len(fact) > AGENT_MAX_CONTENT:
+            fact = fact[:AGENT_MAX_CONTENT] + "…"
+        compact.content = fact.encode()
+        compact.fact_text = fact
+    else:
+        # For file-backed: use fact_summary if available.
+        summary = record.get("fact_summary")
+        if summary:
+            compact.content = summary.encode()
+            compact.fact_text = summary
+        # No summary → no content (agent doesn't read files)
+
+    compact.profile = "agent"
+    return compact
+
+
+def _hydrate_audit(
+    db: MemoryDB,
+    record: dict[str, Any],
+    base_dir: str | None,
+    verify: bool,
+) -> ProfiledHydration:
+    """Content + provenance + checksums + source references + warnings."""
+    result = _hydrate_compact(record)
+    result.profile = "audit"
+
+    if record["memory_type"] != "file":
+        # Inline: content is fact_text.
+        result.content = (record.get("fact_text") or "").encode()
+        result.fact_text = record.get("fact_text")
+    else:
+        # File-backed: actually hydrate (lazy read + verify).
+        try:
+            hydrated = hydrate_memory_detailed(db, record["id"], base_dir=base_dir, verify=verify)
+            result.content = hydrated.content
+            result.verified = hydrated.verified
+            result.source_uri = hydrated.source_uri
+            result.byte_offset = hydrated.byte_offset
+            result.byte_length = hydrated.byte_length
+            result.exists = True
+        except BackingFileMissingError as err:
+            result.warnings.append(f"backing file missing: {err.source_uri}")
+            result.exists = False
+        except ProvenanceError as err:
+            result.warnings.append(f"provenance error ({err.reason}): {err.source_uri}")
+            result.verified = False
+
+    return result
+
+
+def _hydrate_full(
+    db: MemoryDB,
+    record: dict[str, Any],
+    base_dir: str | None,
+    verify: bool,
+) -> ProfiledHydration:
+    """Maximum detail — content, provenance, diagnostics, warnings."""
+    result = _hydrate_audit(db, record, base_dir, verify)
+    result.profile = "full"
+
+    # Add full fact_text for inline memories (audit already has it).
+    if record["memory_type"] != "file":
+        result.fact_text = record.get("fact_text")
+
+    # Add provenance_json if present.
+    provenance = record.get("provenance_json")
+    if provenance:
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            result.warnings.append(f"provenance: {json.loads(provenance)}")
+
+    return result

--- a/src/hotmem/profiles.py
+++ b/src/hotmem/profiles.py
@@ -1,30 +1,30 @@
 """HotMem hydration profiles — profile-aware content and provenance retrieval.
 
 Purpose:
-     Allow consumers to ask for different levels of memory content and
-     provenance without changing existing hydrate defaults. Profiles are
-     additive request parameters; the default hydrate behavior is unchanged.
+      Allow consumers to ask for different levels of memory content and
+      provenance without changing existing hydrate defaults. Profiles are
+      additive request parameters; the default hydrate behavior is unchanged.
 
 Profiles:
-     agent:  concise content (fact_summary or truncated fact_text), no file reads.
-     compact: smallest representation — metadata only, no content, no file reads.
-     audit:   content + provenance, checksums, source references, warnings.
-     full:    maximum detail — inline content, file references, diagnostics.
+      agent:  concise content (fact_summary or truncated fact_text), no file reads.
+      compact: smallest representation — metadata only, no content, no file reads.
+      audit:   content + provenance, checksums, source references, warnings.
+      full:    maximum detail — inline content, file references, provenance, diagnostics.
 
 Rules:
-     - ``compact`` and ``agent`` never call ``adapter.read_range()``.
-     - ``audit`` and ``full`` may read file-backed content (lazy, on demand).
-     - Missing backing files surface as provenance errors (audit/full) or
-       warnings (agent/compact).
-     - Default hydrate (no profile) returns raw bytes — unchanged.
+      - ``compact`` and ``agent`` never call ``adapter.read_range()``.
+      - ``audit`` and ``full`` may read file-backed content (lazy, on demand).
+      - Missing backing files surface as provenance errors (audit/full) or
+        warnings (agent/compact).
+      - Default hydrate (no profile) returns raw bytes — unchanged.
 
 Interface:
-     HydrationProfile = Literal["agent", "compact", "audit", "full"]
-     ProfiledHydration (dataclass): memory_id, identifier, memory_type, content,
-         verified, source_uri, byte_offset, byte_length, source_checksum,
-         fact_summary, warnings, profile
-     hydrate_with_profile(db, memory_id, *, profile="agent", base_dir=None,
-         verify=True) -> ProfiledHydration
+      HydrationProfile = Literal["agent", "compact", "audit", "full"]
+      ProfiledHydration (dataclass): memory_id, identifier, memory_type, content,
+          verified, source_uri, byte_offset, byte_length, source_checksum,
+          fact_summary, provenance, warnings, profile
+      hydrate_with_profile(db, memory_id, *, profile="agent", base_dir=None,
+          verify=True) -> ProfiledHydration
 
 Deps: hotmem.db, hotmem.memory, hotmem.provenance, hotmem.storage, hotmem.trace
 Extension: add custom profiles or profile-specific transformations here.
@@ -35,6 +35,7 @@ from __future__ import annotations
 import contextlib
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal
 
 from hotmem.db import MemoryDB
@@ -74,6 +75,7 @@ class ProfiledHydration:
     source_format: str | None = None
     fact_summary: str | None = None
     fact_text: str | None = None
+    provenance: dict[str, Any] | None = None
     warnings: list[str] = field(default_factory=list)
     exists: bool | None = None  # whether the backing file currently exists
 
@@ -105,11 +107,26 @@ class ProfiledHydration:
             d["fact_summary"] = self.fact_summary
         if self.fact_text:
             d["fact_text"] = self.fact_text
+        if self.provenance is not None:
+            d["provenance"] = self.provenance
         if self.warnings:
             d["warnings"] = self.warnings
         if self.exists is not None:
             d["exists"] = self.exists
         return d
+
+
+def _resolve_source_uri(source_uri: str, base_dir: str | None) -> str:
+    """Resolve a source_uri against base_dir (matches memory._resolve_uri)."""
+    raw = source_uri
+    if raw.startswith("file://"):
+        raw = raw[len("file://") :]
+    if "://" in raw:
+        return source_uri  # non-file scheme, leave as-is
+    path = Path(raw)
+    if not path.is_absolute() and base_dir is not None:
+        path = Path(base_dir) / path
+    return str(path.resolve())
 
 
 def hydrate_with_profile(
@@ -133,7 +150,7 @@ def hydrate_with_profile(
 
     with Timer() as t:
         if profile == "compact":
-            result = _hydrate_compact(record)
+            result = _hydrate_compact(record, base_dir)
         elif profile == "agent":
             result = _hydrate_agent(record, base_dir)
         elif profile == "audit":
@@ -155,16 +172,18 @@ def hydrate_with_profile(
     return result
 
 
-def _hydrate_compact(record: dict[str, Any]) -> ProfiledHydration:
+def _hydrate_compact(record: dict[str, Any], base_dir: str | None) -> ProfiledHydration:
     """Metadata only — no content, no file reads."""
     warnings: list[str] = []
     exists = None
 
     if record["memory_type"] == "file" and record.get("source_uri"):
         # Check if backing file exists (stat only, no read).
+        # Resolve relative URIs against base_dir (matches memory._resolve_uri).
+        resolved = _resolve_source_uri(record["source_uri"], base_dir)
         try:
-            adapter = get_adapter(record["source_uri"])
-            exists = adapter.exists(record["source_uri"])
+            adapter = get_adapter(resolved)
+            exists = adapter.exists(resolved)
             if not exists:
                 warnings.append(f"backing file missing: {record['source_uri']}")
         except Exception:
@@ -188,7 +207,7 @@ def _hydrate_compact(record: dict[str, Any]) -> ProfiledHydration:
 
 def _hydrate_agent(record: dict[str, Any], base_dir: str | None) -> ProfiledHydration:
     """Concise content — fact_summary or truncated fact_text. No file reads."""
-    compact = _hydrate_compact(record)
+    compact = _hydrate_compact(record, base_dir)
 
     # For inline memories: use fact_text (truncated).
     if record["memory_type"] != "file":
@@ -216,8 +235,14 @@ def _hydrate_audit(
     verify: bool,
 ) -> ProfiledHydration:
     """Content + provenance + checksums + source references + warnings."""
-    result = _hydrate_compact(record)
+    result = _hydrate_compact(record, base_dir)
     result.profile = "audit"
+
+    # Add structured provenance from the record.
+    provenance_json = record.get("provenance_json")
+    if provenance_json:
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            result.provenance = json.loads(provenance_json)
 
     if record["memory_type"] != "file":
         # Inline: content is fact_text.
@@ -253,14 +278,10 @@ def _hydrate_full(
     result = _hydrate_audit(db, record, base_dir, verify)
     result.profile = "full"
 
-    # Add full fact_text for inline memories (audit already has it).
+    # Full fact_text for inline memories (audit already has it).
     if record["memory_type"] != "file":
         result.fact_text = record.get("fact_text")
 
-    # Add provenance_json if present.
-    provenance = record.get("provenance_json")
-    if provenance:
-        with contextlib.suppress(json.JSONDecodeError, TypeError):
-            result.warnings.append(f"provenance: {json.loads(provenance)}")
+    # Structured provenance is already set by _hydrate_audit.
 
     return result

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel, Field, model_validator
 from hotmem.db import MemoryDB
 from hotmem.embed import EMBEDDING_DIM, EMBEDDING_MODEL, embed_text, pack_embedding
 from hotmem.memory import FileRef, add_file_backed, get_memory_metadata, hydrate_memory
+from hotmem.profiles import hydrate_with_profile
 from hotmem.provenance import ProvenanceError
 from hotmem.search import search_memories
 from hotmem.snapshot import SnapshotChecksumError
@@ -140,6 +141,17 @@ class SnapshotRequest(BaseModel):
         default=False,
         description="Copy small file-backed byte ranges into attachments/ (v2 only)",
     )
+
+
+class HydrateOneRequest(BaseModel):
+    """Optional body for POST /v1/memory/{id}/hydrate — profile + verify params.
+
+    When absent (no body), the endpoint returns raw bytes (backward-compatible).
+    When present, returns a JSON ProfiledHydration dict.
+    """
+
+    profile: str = Field(default="agent", description="agent|compact|audit|full")
+    verify: bool = Field(default=True, description="Verify source_checksum if present")
 
 
 # ── Lifespan ─────────────────────────────────────────────────────────────────
@@ -367,10 +379,46 @@ def create_app(
         return meta
 
     @app.post("/v1/memory/{memory_id}/hydrate")
-    async def hydrate_one(memory_id: str):
-        """Materialize a memory's payload on demand (lazy hydration)."""
+    async def hydrate_one(memory_id: str, req: HydrateOneRequest | None = None):
+        """Materialize a memory's payload on demand (lazy hydration).
+
+        When no body is sent, returns raw bytes (backward-compatible).
+        When a body with ``profile`` is sent, returns a JSON ProfiledHydration.
+        """
         db: MemoryDB = _state["db"]
         base_dir: str = _state["base_dir"]
+
+        if req is not None:
+            with Timer() as t:
+                try:
+                    ph = hydrate_with_profile(
+                        db,
+                        memory_id,
+                        profile=req.profile,
+                        base_dir=base_dir,
+                        verify=req.verify,
+                    )
+                except KeyError:
+                    return JSONResponse(
+                        status_code=404,
+                        content={"error": "not_found", "memory_id": memory_id},
+                    )
+                except ProvenanceError as err:
+                    return JSONResponse(
+                        status_code=409,
+                        content={
+                            "error": "provenance_mismatch",
+                            "reason": err.reason,
+                            "expected": err.expected,
+                            "actual": err.actual,
+                            "source_uri": err.source_uri,
+                            "message": str(err),
+                        },
+                    )
+            d = ph.to_dict()
+            d["trace_ms"] = round(t.ms, 2)
+            return d
+
         with Timer() as t:
             try:
                 payload = hydrate_memory(db, memory_id, base_dir=base_dir)

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, Field, model_validator
 from hotmem.db import MemoryDB
 from hotmem.embed import EMBEDDING_DIM, EMBEDDING_MODEL, embed_text, pack_embedding
 from hotmem.memory import FileRef, add_file_backed, get_memory_metadata, hydrate_memory
-from hotmem.profiles import hydrate_with_profile
+from hotmem.profiles import HydrationProfile, hydrate_with_profile
 from hotmem.provenance import ProvenanceError
 from hotmem.search import search_memories
 from hotmem.snapshot import SnapshotChecksumError
@@ -150,7 +150,7 @@ class HydrateOneRequest(BaseModel):
     When present, returns a JSON ProfiledHydration dict.
     """
 
-    profile: str = Field(default="agent", description="agent|compact|audit|full")
+    profile: HydrationProfile = Field(default="agent", description="agent|compact|audit|full")
     verify: bool = Field(default=True, description="Verify source_checksum if present")
 
 
@@ -414,6 +414,11 @@ def create_app(
                             "source_uri": err.source_uri,
                             "message": str(err),
                         },
+                    )
+                except ValueError as err:
+                    return JSONResponse(
+                        status_code=400,
+                        content={"error": "invalid_profile", "message": str(err)},
                     )
             d = ph.to_dict()
             d["trace_ms"] = round(t.ms, 2)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,312 @@
+"""Tests for #40 — Hydration Profiles.
+
+Covers acceptance criteria:
+  1. Each profile returns a stable documented shape.
+  2. Default hydrate behavior is unchanged.
+  3. audit includes source URI, byte ranges, checksum state, warnings.
+  4. agent and compact avoid unnecessary file reads.
+  5. Missing backing files surface as provenance errors or warnings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from hotmem.db import MemoryDB
+from hotmem.embed import embed_text, pack_embedding
+from hotmem.memory import FileRef, add_file_backed, hydrate_memory
+from hotmem.profiles import (
+    AGENT_MAX_CONTENT,
+    hydrate_with_profile,
+)
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def inline_memory(tmp_db: MemoryDB) -> str:
+    """An inline memory with known text."""
+    text = "Vendor acme has duplicate invoice risk"
+    blob = pack_embedding(embed_text(text))
+    tmp_db.insert(
+        id="inline1",
+        identifier="vendor_x",
+        fact_text=text,
+        embedding=blob,
+        content_hash=hashlib.sha256(b"vendor_x:" + text.encode()).hexdigest(),
+    )
+    return "inline1"
+
+
+@pytest.fixture
+def file_backed_memory(tmp_db: MemoryDB, fixture_file: Path) -> str:
+    """A file-backed memory with a checksum."""
+    expected = hashlib.sha256(fixture_file.read_bytes()[10:30]).hexdigest()
+    ref = FileRef(
+        source_uri=str(fixture_file),
+        byte_offset=10,
+        byte_length=20,
+        source_format="bin",
+        source_checksum=expected,
+    )
+    mid, _ = add_file_backed(tmp_db, identifier="dataset", file_ref=ref, summary="a slice")
+    return mid
+
+
+# ── 1. Each profile returns a stable shape ────────────────────────────────────
+
+
+def test_compact_profile_shape(tmp_db: MemoryDB, inline_memory: str):
+    result = hydrate_with_profile(tmp_db, inline_memory, profile="compact")
+    assert result.profile == "compact"
+    assert result.memory_id == inline_memory
+    assert result.identifier == "vendor_x"
+    assert result.memory_type != "file"
+    assert result.content is None  # compact: no content
+    assert result.verified is False
+
+
+def test_agent_profile_shape(tmp_db: MemoryDB, inline_memory: str):
+    result = hydrate_with_profile(tmp_db, inline_memory, profile="agent")
+    assert result.profile == "agent"
+    assert result.content is not None  # agent: has content
+    assert b"duplicate invoice" in result.content
+    assert result.fact_text is not None
+
+
+def test_audit_profile_shape(tmp_db: MemoryDB, inline_memory: str):
+    result = hydrate_with_profile(tmp_db, inline_memory, profile="audit")
+    assert result.profile == "audit"
+    assert result.content is not None
+    assert b"Vendor acme" in result.content
+
+
+def test_full_profile_shape(tmp_db: MemoryDB, inline_memory: str):
+    result = hydrate_with_profile(tmp_db, inline_memory, profile="full")
+    assert result.profile == "full"
+    assert result.content is not None
+    assert result.fact_text is not None
+
+
+# ── 2. Default hydrate behavior unchanged ─────────────────────────────────────
+
+
+def test_default_hydrate_returns_bytes(tmp_db: MemoryDB, inline_memory: str):
+    """hydrate_memory() (no profile) still returns raw bytes."""
+    data = hydrate_memory(tmp_db, inline_memory)
+    assert isinstance(data, bytes)
+    assert b"Vendor acme" in data
+
+
+# ── 3. Audit includes provenance for file-backed ──────────────────────────────
+
+
+def test_audit_file_backed_includes_provenance(
+    tmp_db: MemoryDB, file_backed_memory: str, fixture_file: Path
+):
+    result = hydrate_with_profile(tmp_db, file_backed_memory, profile="audit")
+    assert result.profile == "audit"
+    assert result.content is not None
+    assert result.content == fixture_file.read_bytes()[10:30]
+    assert result.verified is True
+    assert result.source_uri == str(fixture_file)
+    assert result.byte_offset == 10
+    assert result.byte_length == 20
+    assert result.source_checksum is not None
+
+
+# ── 4. agent and compact avoid file reads ─────────────────────────────────────
+
+
+def test_compact_no_file_reads(tmp_db: MemoryDB, file_backed_memory: str):
+    """compact profile must not read the backing file."""
+    from spy import SpyAdapter
+
+    from hotmem.storage.local import LocalFilesystemAdapter
+
+    spy = SpyAdapter(LocalFilesystemAdapter())
+    import hotmem.profiles as profiles_mod
+
+    orig = profiles_mod.get_adapter
+    profiles_mod.get_adapter = lambda uri: spy
+
+    try:
+        reads_before = spy.total_file_reads
+        result = hydrate_with_profile(tmp_db, file_backed_memory, profile="compact")
+        reads_after = spy.total_file_reads
+        assert reads_after == reads_before, "compact must not read the backing file"
+        assert result.content is None  # no content
+        assert result.exists is True  # stat-only check is OK
+    finally:
+        profiles_mod.get_adapter = orig
+
+
+def test_agent_no_file_reads(tmp_db: MemoryDB, file_backed_memory: str):
+    """agent profile must not read the backing file (uses summary only)."""
+    from spy import SpyAdapter
+
+    from hotmem.storage.local import LocalFilesystemAdapter
+
+    spy = SpyAdapter(LocalFilesystemAdapter())
+    import hotmem.profiles as profiles_mod
+
+    orig = profiles_mod.get_adapter
+    profiles_mod.get_adapter = lambda uri: spy
+
+    try:
+        reads_before = spy.total_file_reads
+        result = hydrate_with_profile(tmp_db, file_backed_memory, profile="agent")
+        reads_after = spy.total_file_reads
+        assert reads_after == reads_before, "agent must not read the backing file"
+        # agent uses fact_summary, not the file
+        assert result.content is not None
+        assert b"a slice" in result.content
+    finally:
+        profiles_mod.get_adapter = orig
+
+
+def test_agent_truncates_large_inline(tmp_db: MemoryDB):
+    """agent profile truncates inline content over AGENT_MAX_CONTENT."""
+    long_text = "x" * (AGENT_MAX_CONTENT + 1000)
+    blob = pack_embedding(embed_text(long_text))
+    tmp_db.insert(id="long1", identifier="z", fact_text=long_text, embedding=blob)
+    result = hydrate_with_profile(tmp_db, "long1", profile="agent")
+    assert len(result.content) <= AGENT_MAX_CONTENT + 10  # truncated + ellipsis
+
+
+# ── 5. Missing backing files ──────────────────────────────────────────────────
+
+
+def test_audit_missing_file_warns(tmp_db: MemoryDB, file_backed_memory: str, fixture_file: Path):
+    """audit profile surfaces missing backing file as a warning (not crash)."""
+    fixture_file.unlink()
+    result = hydrate_with_profile(tmp_db, file_backed_memory, profile="audit")
+    assert result.content is None  # couldn't read
+    assert result.exists is False
+    assert any("missing" in w.lower() for w in result.warnings)
+
+
+def test_compact_missing_file_warns(tmp_db: MemoryDB, file_backed_memory: str, fixture_file: Path):
+    """compact profile checks existence (stat) and warns if missing."""
+    fixture_file.unlink()
+    result = hydrate_with_profile(tmp_db, file_backed_memory, profile="compact")
+    assert result.exists is False
+    assert any("missing" in w.lower() for w in result.warnings)
+
+
+def test_audit_checksum_mismatch_warns(
+    tmp_db: MemoryDB, file_backed_memory: str, fixture_file: Path
+):
+    """audit profile surfaces checksum mismatch as a warning (not crash)."""
+    fixture_file.write_bytes(b"X" * 1024)  # corrupt the file
+    result = hydrate_with_profile(tmp_db, file_backed_memory, profile="audit")
+    assert result.verified is False
+    assert any("provenance" in w.lower() for w in result.warnings)
+
+
+# ── to_dict serialization ─────────────────────────────────────────────────────
+
+
+def test_profiled_hydration_to_dict(tmp_db: MemoryDB, inline_memory: str):
+    result = hydrate_with_profile(tmp_db, inline_memory, profile="audit")
+    d = result.to_dict()
+    assert d["memory_id"] == inline_memory
+    assert d["profile"] == "audit"
+    assert "content" in d
+    assert d["content_encoding"] == "base64"
+
+
+# ── HTTP endpoint tests (#40: hydrate with profile) ───────────────────────────
+
+
+@pytest.fixture
+def app_client_with_data(tmp_path: Path, fixture_file: Path):
+    """A TestClient with one inline + one file-backed memory."""
+    from fastapi.testclient import TestClient
+
+    from hotmem.server import create_app
+
+    mount = tmp_path / "mount"
+    mount.mkdir()
+    target = mount / fixture_file.name
+    target.write_bytes(fixture_file.read_bytes())
+
+    app = create_app(db_path=mount / "hotmem.sqlite", base_dir=mount)
+    with TestClient(app) as c:
+        c.mount_dir = mount  # type: ignore[attr-defined]
+        c.fixture_path = target  # type: ignore[attr-defined]
+        c.post("/v1/add", json={"identifier": "vendor_x", "fact": "inline fact about acme"})
+        chk = hashlib.sha256(fixture_file.read_bytes()[0:20]).hexdigest()
+        resp = c.post(
+            "/v1/add",
+            json={
+                "identifier": "dataset",
+                "file_uri": fixture_file.name,
+                "byte_offset": 0,
+                "byte_length": 20,
+                "source_format": "bin",
+                "source_checksum": chk,
+                "summary": "acme data slice",
+            },
+        )
+        c._file_backed_id = resp.json()["memory_id"]  # type: ignore[attr-defined]
+        c._inline_id = c.post(  # type: ignore[attr-defined]
+            "/v1/add", json={"identifier": "vendor_y", "fact": "another fact"}
+        ).json()["memory_id"]
+        yield c
+
+
+def test_hydrate_with_profile_returns_json(app_client_with_data):
+    """POST /v1/memory/{id}/hydrate with a body returns JSON, not bytes."""
+
+    mid = app_client_with_data._inline_id  # type: ignore[attr-defined]
+    resp = app_client_with_data.post(
+        f"/v1/memory/{mid}/hydrate",
+        json={"profile": "agent", "verify": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["profile"] == "agent"
+    assert "content" in body
+    assert body["content_encoding"] == "base64"
+
+
+def test_hydrate_without_body_returns_bytes(app_client_with_data):
+    """POST /v1/memory/{id}/hydrate without a body returns raw bytes."""
+
+    mid = app_client_with_data._inline_id  # type: ignore[attr-defined]
+    resp = app_client_with_data.post(f"/v1/memory/{mid}/hydrate")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/octet-stream"
+    assert b"another fact" in resp.content
+
+
+def test_hydrate_compact_no_content_via_api(app_client_with_data):
+
+    mid = app_client_with_data._inline_id  # type: ignore[attr-defined]
+    resp = app_client_with_data.post(
+        f"/v1/memory/{mid}/hydrate",
+        json={"profile": "compact"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["profile"] == "compact"
+    assert "content" not in body
+
+
+def test_hydrate_audit_file_backed_via_api(app_client_with_data):
+
+    mid = app_client_with_data._file_backed_id  # type: ignore[attr-defined]
+    resp = app_client_with_data.post(
+        f"/v1/memory/{mid}/hydrate",
+        json={"profile": "audit", "verify": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["profile"] == "audit"
+    assert body["verified"] is True
+    assert body["source_uri"] is not None
+    assert "content" in body


### PR DESCRIPTION
## What
Allow consumers to ask for different levels of memory content and provenance without changing existing hydrate defaults. Four profiles: agent (concise), compact (metadata only), audit (content + provenance), full (everything).

## Why
The file-backed memory foundation (#38) added `hydrate_memory_detailed()` returning `HydratedContent`. This ticket adds profile-aware hydration: `compact` and `agent` never read files (zero file I/O), `audit` and `full` may hydrate file-backed content with checksum verification. Profiles are additive request parameters — default hydrate behavior is unchanged.

## Changes
- **`src/hotmem/profiles.py`** (new) — `HydrationProfile = agent|compact|audit|full`; `ProfiledHydration` dataclass with optional fields per profile; `hydrate_with_profile()` — compact/agent never call `adapter.read_range()` (spy-proven); audit/full may hydrate with verify; missing backing files surface as warnings (not crashes)
- **`server.py`** — `POST /v1/memory/{id}/hydrate` now accepts an optional `HydrateOneRequest` body with `profile` + `verify`; no body → raw bytes (backward-compatible); with body → JSON `ProfiledHydration`
- **`tests/test_profiles.py`** (17 tests) — each profile shape, default hydrate unchanged, audit provenance, compact/agent zero reads (spy), agent truncation, missing-file warnings, HTTP endpoint tests

## Checklist
- [x] Tests pass (243 total, 17 new)
- [x] Lint passes
- [x] No new dependencies

Closes #40. Depends on #38 (PR #56) and #50 (PR #60).