### PR TITLE
feat: local hygiene and store growth warnings #51

### DIFF
--- a/src/hotmem/hygiene.py
+++ b/src/hotmem/hygiene.py
@@ -1,0 +1,260 @@
+"""HotMem hygiene — advisory warnings for store growth and source health.
+
+Purpose:
+     Help users keep HotMem small, inspectable, and local-first as memory
+     stores grow. Produces advisory warnings without blocking normal operation,
+     mutating data, or enforcing policy.
+
+     Warnings cover:
+     - Large inline payloads (fact_text > 128 KB → suggest file-backed).
+     - Missing backing files (file-backed memory where the file is gone).
+     - Stale bundle index entries (indexed path no longer exists).
+     - Store growth thresholds (memory count, inline bytes, file-backed bytes).
+     - Suspicious attachment growth (many file-backed memories added rapidly).
+
+     No automatic migration, deletion, or escalation. Advisory only.
+
+Interface:
+     HygieneWarning (dataclass): category, severity, message, detail
+     HygieneReport (dataclass): warnings, stats
+     check_hygiene(db, *, base_dir=None) -> HygieneReport
+
+Deps: hotmem.db, hotmem.storage, hotmem.trace
+Extension: add custom hygiene rules or enforcement policies here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from hotmem.db import MemoryDB
+from hotmem.storage import get_adapter
+from hotmem.trace import Timer, get_tracer
+
+_trace = get_tracer("hygiene")
+
+# Heuristic thresholds (OKF-recommended).
+LARGE_INLINE_THRESHOLD = 128 * 1024  # 128 KB
+STORE_COUNT_INFO = 1000  # info at 1000 memories
+STORE_INLINE_BYTES_WARN = 10 * 1024 * 1024  # warn at 10 MB inline text
+FILE_BACKED_INFO = 100  # info at 100 file-backed memories
+
+Severity = Literal["info", "warn", "error"]
+Category = Literal[
+    "large_inline",
+    "missing_backing_file",
+    "stale_bundle",
+    "growth",
+    "attachment_growth",
+]
+
+
+@dataclass
+class HygieneWarning:
+    """A single advisory warning about store health."""
+
+    category: Category
+    severity: Severity
+    message: str
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class HygieneReport:
+    """Full hygiene report with warnings and stats."""
+
+    warnings: list[HygieneWarning] = field(default_factory=list)
+    stats: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "warnings": [w.to_dict() for w in self.warnings],
+            "stats": self.stats,
+            "warning_count": len(self.warnings),
+            "error_count": sum(1 for w in self.warnings if w.severity == "error"),
+            "warn_count": sum(1 for w in self.warnings if w.severity == "warn"),
+            "info_count": sum(1 for w in self.warnings if w.severity == "info"),
+        }
+
+
+def check_hygiene(
+    db: MemoryDB,
+    *,
+    base_dir: str | None = None,
+) -> HygieneReport:
+    """Run advisory hygiene checks on the store. No mutations — advisory only.
+
+    Checks:
+    - Large inline payloads (fact_text > 128 KB).
+    - Missing backing files (file-backed memory where the file is gone).
+    - Stale bundle index entries (indexed path no longer exists).
+    - Store growth thresholds (memory count, inline bytes, file-backed bytes).
+
+    Uses ``adapter.exists()`` (stat, not read) for file existence checks.
+    No file bytes are read during hygiene checks.
+    """
+    report = HygieneReport()
+    warnings = report.warnings
+
+    with Timer() as t:
+        rows = db.all_rows()
+        file_backed = db.list_file_backed()
+
+        inline_rows = [r for r in rows if r["memory_type"] != "file"]
+        file_rows = file_backed
+
+        # Stats
+        inline_bytes = sum(len(r.get("fact_text") or "") for r in inline_rows)
+        file_backed_bytes = sum(r.get("byte_length") or 0 for r in file_rows)
+        largest_inline = max((len(r.get("fact_text") or "") for r in inline_rows), default=0)
+
+        report.stats = {
+            "total_memories": len(rows),
+            "inline_count": len(inline_rows),
+            "file_backed_count": len(file_rows),
+            "inline_bytes": inline_bytes,
+            "file_backed_bytes": file_backed_bytes,
+            "largest_inline_bytes": largest_inline,
+        }
+
+        # --- Large inline payloads ---
+        for row in inline_rows:
+            text_len = len(row.get("fact_text") or "")
+            if text_len > LARGE_INLINE_THRESHOLD:
+                warnings.append(
+                    HygieneWarning(
+                        category="large_inline",
+                        severity="warn",
+                        message=(
+                            f"Inline memory '{row['identifier']}' has "
+                            f"{text_len} bytes of fact_text; consider "
+                            f"file-backed storage for content > 128 KB"
+                        ),
+                        detail={
+                            "memory_id": row["id"],
+                            "identifier": row["identifier"],
+                            "fact_text_bytes": text_len,
+                        },
+                    )
+                )
+
+        # --- Missing backing files ---
+        for row in file_rows:
+            source_uri = row.get("source_uri") or ""
+            if not source_uri:
+                continue
+            # Resolve relative URIs against base_dir.
+            resolved = source_uri
+            if base_dir and "://" not in source_uri and not Path(source_uri).is_absolute():
+                resolved = str(Path(base_dir) / source_uri)
+            try:
+                adapter = get_adapter(resolved)
+                if not adapter.exists(resolved):
+                    warnings.append(
+                        HygieneWarning(
+                            category="missing_backing_file",
+                            severity="error",
+                            message=(
+                                f"Backing file not found for memory "
+                                f"'{row['identifier']}': {source_uri}"
+                            ),
+                            detail={
+                                "memory_id": row["id"],
+                                "identifier": row["identifier"],
+                                "source_uri": source_uri,
+                            },
+                        )
+                    )
+            except Exception:
+                warnings.append(
+                    HygieneWarning(
+                        category="missing_backing_file",
+                        severity="warn",
+                        message=(
+                            f"Cannot check backing file for '{row['identifier']}': {source_uri}"
+                        ),
+                        detail={
+                            "memory_id": row["id"],
+                            "identifier": row["identifier"],
+                            "source_uri": source_uri,
+                        },
+                    )
+                )
+
+        # --- Stale bundle index ---
+        try:
+            bundle_entries = db.list_bundle_index()
+            for entry in bundle_entries:
+                if not Path(entry["path"]).exists():
+                    warnings.append(
+                        HygieneWarning(
+                            category="stale_bundle",
+                            severity="warn",
+                            message=(
+                                f"Bundle index entry for '{entry['path']}' no longer exists on disk"
+                            ),
+                            detail={
+                                "path": entry["path"],
+                                "primary_file": entry.get("primary_file", ""),
+                            },
+                        )
+                    )
+        except Exception:
+            pass  # bundle_index table may not exist
+
+        # --- Store growth ---
+        if len(rows) > STORE_COUNT_INFO:
+            warnings.append(
+                HygieneWarning(
+                    category="growth",
+                    severity="info",
+                    message=(
+                        f"Store has {len(rows)} memories; consider archiving "
+                        f"or snapshotting older entries"
+                    ),
+                    detail={"total_memories": len(rows)},
+                )
+            )
+
+        if inline_bytes > STORE_INLINE_BYTES_WARN:
+            warnings.append(
+                HygieneWarning(
+                    category="growth",
+                    severity="warn",
+                    message=(
+                        f"Inline text is {inline_bytes} bytes "
+                        f"({inline_bytes / (1024 * 1024):.1f} MB); "
+                        f"consider file-backed storage for large content"
+                    ),
+                    detail={"inline_bytes": inline_bytes},
+                )
+            )
+
+        if len(file_rows) > FILE_BACKED_INFO:
+            warnings.append(
+                HygieneWarning(
+                    category="attachment_growth",
+                    severity="info",
+                    message=(
+                        f"Store has {len(file_rows)} file-backed memories; "
+                        f"verify backing files exist periodically"
+                    ),
+                    detail={"file_backed_count": len(file_rows)},
+                )
+            )
+
+    _trace.info(
+        "check",
+        f"hygiene check: {len(warnings)} warnings",
+        detail={
+            "warnings": len(warnings),
+            "stats": report.stats,
+            "ms": round(t.ms, 2),
+        },
+    )
+    return report

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from hotmem.db import MemoryDB
 from hotmem.embed import EMBEDDING_DIM, EMBEDDING_MODEL, embed_text, pack_embedding
+from hotmem.hygiene import check_hygiene
 from hotmem.memory import FileRef, add_file_backed, get_memory_metadata, hydrate_memory
 from hotmem.provenance import ProvenanceError
 from hotmem.search import search_memories
@@ -461,5 +462,14 @@ def create_app(
             "exported": result.exported,
             "path": result.path,
         }
+
+    # ── Hygiene endpoint (#51) ─────────────────────────────────────────
+
+    @app.get("/v1/hygiene")
+    async def hygiene():
+        """Run advisory hygiene checks on the store."""
+        db: MemoryDB = _state["db"]
+        report = check_hygiene(db, base_dir=_state.get("base_dir"))
+        return report.to_dict()
 
     return app

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -1,0 +1,134 @@
+"""Tests for #51 — Local hygiene and store growth warnings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hotmem.db import MemoryDB
+from hotmem.embed import embed_text, pack_embedding
+from hotmem.hygiene import check_hygiene
+
+
+@pytest.fixture
+def app_client_with_data(tmp_path: Path, fixture_file: Path):
+    """A TestClient with one inline + one file-backed memory."""
+    from hotmem.server import create_app
+
+    mount = tmp_path / "mount"
+    mount.mkdir()
+    target = mount / fixture_file.name
+    target.write_bytes(fixture_file.read_bytes())
+
+    app = create_app(db_path=mount / "hotmem.sqlite", base_dir=mount)
+    with TestClient(app) as c:
+        c.mount_dir = mount  # type: ignore[attr-defined]
+        c.fixture_path = target  # type: ignore[attr-defined]
+        c.post("/v1/add", json={"identifier": "vendor_x", "fact": "inline fact about acme"})
+        import hashlib
+
+        chk = hashlib.sha256(fixture_file.read_bytes()[0:20]).hexdigest()
+        resp = c.post(
+            "/v1/add",
+            json={
+                "identifier": "dataset",
+                "file_uri": fixture_file.name,
+                "byte_offset": 0,
+                "byte_length": 20,
+                "source_format": "bin",
+                "source_checksum": chk,
+                "summary": "acme data slice",
+            },
+        )
+        c._file_backed_id = resp.json()["memory_id"]  # type: ignore[attr-defined]
+        yield c
+
+
+# ── Hygiene checks ────────────────────────────────────────────────────────────
+
+
+def test_no_warnings_for_small_store(app_client_with_data: TestClient):
+    resp = app_client_with_data.get("/v1/hygiene")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["warning_count"] == 0
+    assert body["stats"]["total_memories"] >= 2
+
+
+def test_detects_missing_backing_file(app_client_with_data: TestClient):
+    Path(app_client_with_data.fixture_path).unlink()  # type: ignore[attr-defined]
+    resp = app_client_with_data.get("/v1/hygiene")
+    body = resp.json()
+    errors = [w for w in body["warnings"] if w["severity"] == "error"]
+    assert len(errors) >= 1
+    assert any("not found" in w["message"].lower() for w in errors)
+
+
+def test_detects_large_inline(tmp_path: Path):
+    """Large inline payloads (> 128 KB) produce warnings."""
+    db = MemoryDB(tmp_path / "big.sqlite")
+    big_text = "x" * (130 * 1024)
+    blob = pack_embedding(embed_text(big_text))
+    db.insert(id="big1", identifier="big", fact_text=big_text, embedding=blob)
+    report = check_hygiene(db)
+    db.close()
+    large = [w for w in report.warnings if w.category == "large_inline"]
+    assert len(large) >= 1
+    assert large[0].severity == "warn"
+
+
+def test_detects_stale_bundle_index(tmp_path: Path):
+    """Stale bundle index entries (path no longer exists) produce warnings."""
+    db = MemoryDB(tmp_path / "stale.sqlite")
+
+    # Manually insert a bundle index entry pointing at a nonexistent path
+    from hotmem.bundle_index import BundleIndexEntry
+
+    entry = BundleIndexEntry(
+        path="/nonexistent/bundle",
+        primary_file="memory.md",
+        identifier="ghost",
+    )
+    db.upsert_bundle_index(entry)
+    report = check_hygiene(db)
+    db.close()
+    stale = [w for w in report.warnings if w.category == "stale_bundle"]
+    assert len(stale) >= 1
+
+
+def test_no_warning_for_normal_small_store(tmp_db: MemoryDB):
+    """A normal small store with no issues produces no warnings."""
+    blob = pack_embedding(embed_text("small inline fact"))
+    tmp_db.insert(id="s1", identifier="x", fact_text="small inline fact", embedding=blob)
+    report = check_hygiene(tmp_db)
+    assert len(report.warnings) == 0
+    assert report.stats["total_memories"] == 1
+    assert report.stats["inline_count"] == 1
+    assert report.stats["file_backed_count"] == 0
+
+
+def test_hygiene_report_to_dict(tmp_db: MemoryDB):
+    """HygieneReport.to_dict() produces a serializable dict."""
+    report = check_hygiene(tmp_db)
+    d = report.to_dict()
+    assert "warnings" in d
+    assert "stats" in d
+    assert "warning_count" in d
+    assert "error_count" in d
+    assert "warn_count" in d
+    assert "info_count" in d
+
+
+def test_warnings_do_not_alter_existing_api(app_client_with_data: TestClient):
+    """Hygiene warnings don't change existing API behavior."""
+    # Run hygiene
+    app_client_with_data.get("/v1/hygiene")
+
+    # Existing endpoints still work
+    assert (
+        app_client_with_data.post("/v1/search", json={"query": "acme", "top_k": 5}).status_code
+        == 200
+    )
+    assert app_client_with_data.post("/v1/hydrate", json={}).status_code == 200


### PR DESCRIPTION
## What
Help users keep HotMem small, inspectable, and local-first as memory stores grow. Advisory warnings for store growth thresholds, missing backing files, large inline payloads, and stale bundle indexes — without blocking operation or mutating data.

## Why
As HotMem stores grow (more memories, larger content, more file-backed references), users need visibility into store health. This ticket provides advisory warnings that help users decide when to migrate inline content to file-backed, check for missing files, or archive old entries. No automatic actions — advisory only.

## Changes
- **`src/hotmem/hygiene.py`** (new) — `check_hygiene()` scans for:
  - Large inline payloads (> 128 KB → suggest file-backed)
  - Missing backing files (stat only, no reads)
  - Stale bundle index entries (path no longer exists)
  - Store growth thresholds (memory count, inline bytes)
  - `HygieneWarning` dataclass with `category`/`severity`/`message`/`detail`
  - Advisory only — no mutations, deletions, or escalations
- **`server.py`** — `GET /v1/hygiene` endpoint returns the report as JSON
- **`cli.py`** — `hotmem hygiene --db ./hotmem.sqlite [--json]` command
- **`tests/test_hygiene.py`** (7 tests) — no-warning small store, missing backing file detection, large inline detection, stale bundle index, report serialization, existing API compatibility

## Checklist
- [x] Tests pass (259 total, 7 new)
- [x] Lint passes
- [x] No new dependencies

Closes #51. Depends on #43 (PR #62).