### PR TITLE
feat: append-only event log + /v1/events (#41)

### DIFF
--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -168,6 +168,25 @@ CREATE TABLE IF NOT EXISTS bundle_index (
     warning_count    INTEGER DEFAULT 0,
     discovered_at    TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
+
+-- #41: Append-only local event log for memory lifecycle and store signals.
+-- Ordering is deterministic via the monotonic `seq` AUTOINCREMENT; `event_id`
+-- is a stable client-facing identifier that survives re-pagination. Reads are
+-- pure SQL — no file hydration ever. UPDATE/DELETE are intentionally absent
+-- from the public surface (retention helpers exist but are not exposed via API).
+CREATE TABLE IF NOT EXISTS events (
+    seq          INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id     TEXT    NOT NULL UNIQUE,
+    memory_id    TEXT,
+    namespace    TEXT    DEFAULT '',
+    event_type   TEXT    NOT NULL,
+    occurred_at  TEXT    NOT NULL,
+    payload_json TEXT    DEFAULT '{{}}'
+);
+CREATE INDEX IF NOT EXISTS idx_events_memory_seq   ON events(memory_id, seq);
+CREATE INDEX IF NOT EXISTS idx_events_namespace_seq ON events(namespace, seq);
+CREATE INDEX IF NOT EXISTS idx_events_type_seq     ON events(event_type, seq);
+CREATE INDEX IF NOT EXISTS idx_events_occurred_seq ON events(occurred_at, seq);
 """
 
 _FTS_TOKEN_RE = re.compile(r"[\w]+")
@@ -297,6 +316,15 @@ class MemoryDB:
         if current_version < 2:
             self._conn.execute("PRAGMA user_version = 2")
             self._conn.commit()
+
+        # #41: events table is created idempotently by _SCHEMA. We bump
+        # user_version to 3 so callers can detect that the event log surface
+        # is available. No backfill is performed — existing memories continue
+        # to operate without lifecycle history.
+        if current_version < 3:
+            self._conn.execute("PRAGMA user_version = 3")
+            self._conn.commit()
+            _trace.info("migrate", "events table available; user_version=3")
 
         try:
             self._conn.execute(
@@ -502,6 +530,123 @@ class MemoryDB:
         """Remove all bundle index entries."""
         self._conn.execute("DELETE FROM bundle_index")
         self._conn.commit()
+
+    # ── Event log (#41) ────────────────────────────────────────────────
+
+    def append_event(
+        self,
+        *,
+        event_type: str,
+        event_id: str,
+        memory_id: str | None = None,
+        namespace: str = "",
+        occurred_at: str,
+        payload_json: str = "{}",
+    ) -> int:
+        """Append one row to the local event log. Returns the monotonic ``seq``.
+
+        This is the only sanctioned write path into ``events``. There is no
+        UPDATE/DELETE method on the public surface — the log is append-only.
+        ``occurred_at`` is supplied by the caller so callers control timestamp
+        semantics (UTC ISO-8601) and tests can inject deterministic times.
+        """
+        cursor = self._conn.execute(
+            """INSERT INTO events
+                   (event_id, memory_id, namespace, event_type, occurred_at, payload_json)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (event_id, memory_id, namespace, event_type, occurred_at, payload_json),
+        )
+        self._conn.commit()
+        return int(cursor.lastrowid)
+
+    def query_events(
+        self,
+        *,
+        memory_id: str | None = None,
+        namespace: str | None = None,
+        event_type: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        after_seq: int | None = None,
+        before_seq: int | None = None,
+        limit: int = 100,
+        ascending: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Return event rows matching the supplied filters, ordered by ``seq``.
+
+        Pagination cursors:
+            ``after_seq``  — return events with seq strictly greater (forward).
+            ``before_seq`` — return events with seq strictly less (backward).
+
+        When ``ascending`` is False, rows are returned newest-first, which
+        flips the meaning of the cursor relative to the result window but
+        keeps ``seq`` as the deterministic tiebreaker.
+
+        Pure SQL — never touches the storage adapter or any backing file.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        if memory_id is not None:
+            clauses.append("memory_id = ?")
+            params.append(memory_id)
+        if namespace is not None:
+            clauses.append("namespace = ?")
+            params.append(namespace)
+        if event_type is not None:
+            clauses.append("event_type = ?")
+            params.append(event_type)
+        if since is not None:
+            clauses.append("occurred_at >= ?")
+            params.append(since)
+        if until is not None:
+            clauses.append("occurred_at <= ?")
+            params.append(until)
+        if after_seq is not None:
+            clauses.append("seq > ?")
+            params.append(after_seq)
+        if before_seq is not None:
+            clauses.append("seq < ?")
+            params.append(before_seq)
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        direction = "ASC" if ascending else "DESC"
+        rows = self._conn.execute(
+            f"""SELECT seq, event_id, memory_id, namespace, event_type,
+                      occurred_at, payload_json
+               FROM events{where}
+               ORDER BY seq {direction}
+               LIMIT ?""",
+            (*params, limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def trim_events_before_seq(self, seq: int) -> int:
+        """Local retention helper: delete events with ``seq < seq``.
+
+        Unexposed via the HTTP API in this ticket — retention remains a
+        local, explicit operation. Returns the number of deleted rows.
+        """
+        cursor = self._conn.execute("DELETE FROM events WHERE seq < ?", (seq,))
+        self._conn.commit()
+        return cursor.rowcount if cursor.rowcount != -1 else 0
+
+    def trim_events_by_count(self, keep: int) -> int:
+        """Local retention helper: keep only the most recent ``keep`` events.
+
+        Unexposed via the HTTP API in this ticket. Returns the number of
+        deleted rows. ``keep`` must be non-negative; ``keep=0`` clears the log.
+        """
+        if keep < 0:
+            raise ValueError("keep must be non-negative")
+        cursor = self._conn.execute(
+            """DELETE FROM events
+               WHERE seq NOT IN (
+                   SELECT seq FROM events ORDER BY seq DESC LIMIT ?
+               )""",
+            (keep,),
+        )
+        self._conn.commit()
+        return cursor.rowcount if cursor.rowcount != -1 else 0
 
     def insert_many_ignore(self, records: Iterable[MemoryRecord]) -> int:
         """Insert many memory rows in one transaction, ignoring duplicate hashes/ids."""

--- a/src/hotmem/events.py
+++ b/src/hotmem/events.py
@@ -1,0 +1,195 @@
+"""HotMem events — append-only local event log for memory lifecycle and signals.
+
+Purpose:
+     Retain an inspectable local history of memory changes, hydration-relevant
+     provenance changes, lifecycle transitions, snapshot/bundle imports, and
+     advisory warnings. Retention is local and explicit — there is no remote
+     event infrastructure, no distributed log, and no public write endpoint:
+     events are appended as side effects of HotMem actions.
+
+     EMOS owns policy, workflows, approvals, remote storage, and
+     orchestration. HotMem only records local, append-only facts.
+
+Interface:
+     EventType — string constants for the canonical event types.
+     append_event(db, *, event_type, memory_id=None, namespace="", payload=None,
+                  occurred_at=None) -> dict
+     query_events(db, *, memory_id=None, namespace=None, event_type=None,
+                  since=None, until=None, after_seq=None, before_seq=None,
+                  limit=100, ascending=True) -> dict
+
+Event ordering & identifiers:
+     Events are ordered deterministically by the monotonic ``seq`` column (a
+     SQLite AUTOINCREMENT primary key). Each event also carries a stable
+     ``event_id`` (UUID4 hex) so clients can reference a specific event across
+     re-pagination without depending on the internal sequence.
+
+Payload contract:
+     ``payload`` is a free-form dict, stored as JSON. Each ``event_type`` has a
+     documented expected shape below; unknown extra keys are tolerated so new
+     fields can be added additively without breaking existing readers.
+
+     memory.created:
+         {memory_type: "fact"|"file", identifier: str, content_hash: str,
+          source_uri?: str, byte_offset?: int, byte_length?: int,
+          source_format?: str}
+     memory.updated:
+         {identifier: str, content_hash: str, reason?: str}
+     memory.provenance_changed:
+         {source_uri: str, byte_offset: int, byte_length: int,
+          source_checksum?: str}
+     memory.promotion:
+         {from: str, to: str, reason?: str, actor?: str}
+     memory.candidate:
+         {candidate: bool, reason?: str}
+     snapshot.imported:
+         {loaded: int, skipped_dupes: int, path: str, format: str}
+     bundle.imported:
+         {loaded: int, skipped_dupes: int, path: str, identifier: str}
+     bundle.discovered:
+         {root: str, discovered: int, indexed: int, warnings: int}
+     hygiene.checked:
+         {warning_count: int, error_count: int, warn_count: int, info_count: int}
+     hygiene.warning:
+         {category: str, severity: str, memory_id?: str, source_uri?: str,
+          message: str}
+
+Deps: hotmem.db, hotmem.trace
+Extension: add new event types here and document their payload shape above.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import uuid
+from typing import Any
+
+from hotmem.db import MemoryDB
+from hotmem.trace import get_tracer
+
+_trace = get_tracer("events")
+
+
+# Canonical event type strings. String literals (not enums) match the
+# codebase convention for stored values and keep the log introspectable
+# via plain SQL without importing this module.
+class EventType:
+    MEMORY_CREATED = "memory.created"
+    MEMORY_UPDATED = "memory.updated"
+    MEMORY_PROVENANCE_CHANGED = "memory.provenance_changed"
+    MEMORY_PROMOTION = "memory.promotion"
+    MEMORY_CANDIDATE = "memory.candidate"
+    SNAPSHOT_IMPORTED = "snapshot.imported"
+    BUNDLE_IMPORTED = "bundle.imported"
+    BUNDLE_DISCOVERED = "bundle.discovered"
+    HYGIENE_CHECKED = "hygiene.checked"
+    HYGIENE_WARNING = "hygiene.warning"
+
+
+def _utc_now_iso() -> str:
+    """Current UTC time as ISO-8601 (stdlib only)."""
+    return _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def append_event(
+    db: MemoryDB,
+    *,
+    event_type: str,
+    memory_id: str | None = None,
+    namespace: str = "",
+    payload: dict[str, Any] | None = None,
+    occurred_at: str | None = None,
+) -> dict[str, Any]:
+    """Append one event to the local log and return the stored row as a dict.
+
+    ``occurred_at`` defaults to the current UTC time. The payload is JSON-encoded
+    with ``sort_keys=True`` for stable diffability. The returned dict matches
+    the shape returned by ``query_events`` (one entry under ``events``).
+    """
+    event_id = uuid.uuid4().hex
+    occurred_at = occurred_at or _utc_now_iso()
+    payload_json = json.dumps(payload or {}, sort_keys=True, default=str)
+    seq = db.append_event(
+        event_type=event_type,
+        event_id=event_id,
+        memory_id=memory_id,
+        namespace=namespace,
+        occurred_at=occurred_at,
+        payload_json=payload_json,
+    )
+    return {
+        "seq": seq,
+        "event_id": event_id,
+        "memory_id": memory_id,
+        "namespace": namespace,
+        "event_type": event_type,
+        "occurred_at": occurred_at,
+        "payload": payload or {},
+    }
+
+
+def query_events(
+    db: MemoryDB,
+    *,
+    memory_id: str | None = None,
+    namespace: str | None = None,
+    event_type: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    after_seq: int | None = None,
+    before_seq: int | None = None,
+    limit: int = 100,
+    ascending: bool = True,
+) -> dict[str, Any]:
+    """Return a paginated, filtered event listing.
+
+    Response shape:
+        {"events": [...], "count": N, "next_seq": int|None, "trace_ms": ...}
+
+    ``next_seq`` is the seq of the last (ascending) or first (descending)
+    returned event, or None when the result window is empty or exhausted.
+    Pure SQL read — never triggers file hydration.
+    """
+    rows = db.query_events(
+        memory_id=memory_id,
+        namespace=namespace,
+        event_type=event_type,
+        since=since,
+        until=until,
+        after_seq=after_seq,
+        before_seq=before_seq,
+        limit=limit,
+        ascending=ascending,
+    )
+    events = [_row_to_event(r) for r in rows]
+    # The cursor is the seq of the last item in display order — the boundary
+    # the caller feeds back as ``after_seq`` (ascending) or ``before_seq``
+    # (descending) to fetch the next page.
+    next_seq = None if not events else events[-1]["seq"]
+    return {
+        "events": events,
+        "count": len(events),
+        "next_seq": next_seq,
+    }
+
+
+def _row_to_event(row: dict[str, Any]) -> dict[str, Any]:
+    """Decode a stored events row into the public event dict shape."""
+    payload = row.get("payload_json")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+    else:
+        payload = payload or {}
+    return {
+        "seq": row["seq"],
+        "event_id": row["event_id"],
+        "memory_id": row["memory_id"],
+        "namespace": row["namespace"],
+        "event_type": row["event_type"],
+        "occurred_at": row["occurred_at"],
+        "payload": payload,
+    }

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -780,9 +780,7 @@ def create_app(
         if order not in ("asc", "desc"):
             raise HTTPException(status_code=400, detail="order must be 'asc' or 'desc'")
         if limit < 1 or limit > 1000:
-            raise HTTPException(
-                status_code=400, detail="limit must be between 1 and 1000"
-            )
+            raise HTTPException(status_code=400, detail="limit must be between 1 and 1000")
         with Timer() as t:
             listing = query_events(
                 db,

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from hotmem.db import MemoryDB
 from hotmem.embed import EMBEDDING_DIM, EMBEDDING_MODEL, embed_text, pack_embedding
+from hotmem.events import EventType, append_event, query_events
 from hotmem.hygiene import check_hygiene
 from hotmem.memory import FileRef, add_file_backed, get_memory_metadata, hydrate_memory
 from hotmem.profiles import HydrationProfile, hydrate_with_profile
@@ -186,6 +187,27 @@ async def lifespan(app: FastAPI):
     # Auto-hydrate if swap file exists
     if swap_path and Path(swap_path).exists():
         result = snapshot_hydrate(db, swap_path)
+        from hotmem.events import EventType as _EventType
+        from hotmem.events import append_event as _append_event
+
+        try:
+            from hotmem.snapshot import detect_format as _detect_format
+
+            fmt = _detect_format(swap_path)
+        except Exception:
+            fmt = "legacy"
+        _append_event(
+            db,
+            event_type=(
+                _EventType.BUNDLE_IMPORTED if fmt == "bundle" else _EventType.SNAPSHOT_IMPORTED
+            ),
+            payload={
+                "loaded": result.loaded,
+                "skipped_dupes": result.skipped_dupes,
+                "path": str(swap_path),
+                "format": fmt,
+            },
+        )
         _trace.info(
             "startup",
             f"auto-hydrated {result.loaded} memories",
@@ -303,6 +325,20 @@ def create_app(
                             "message": str(err),
                         },
                     )
+                append_event(
+                    db,
+                    event_type=EventType.MEMORY_CREATED,
+                    memory_id=memory_id,
+                    payload={
+                        "memory_type": "file",
+                        "identifier": req.identifier,
+                        "content_hash": content_hash,
+                        "source_uri": ref.source_uri,
+                        "byte_offset": ref.byte_offset,
+                        "byte_length": ref.byte_length,
+                        "source_format": ref.source_format,
+                    },
+                )
             else:
                 # Inline path (unchanged from v1).
                 memory_id = uuid.uuid4().hex
@@ -322,6 +358,16 @@ def create_app(
                     metadata_json=json.dumps(req.metadata),
                     content_hash=content_hash,
                     ttl_seconds=req.ttl_seconds,
+                )
+                append_event(
+                    db,
+                    event_type=EventType.MEMORY_CREATED,
+                    memory_id=memory_id,
+                    payload={
+                        "memory_type": "fact",
+                        "identifier": req.identifier,
+                        "content_hash": content_hash,
+                    },
                 )
         return {
             "memory_id": memory_id,
@@ -497,6 +543,25 @@ def create_app(
             )
         except ValueError as err:
             raise HTTPException(status_code=400, detail=str(err)) from err
+        # Record import event without altering the response shape.
+        from hotmem.snapshot import detect_format as _detect_format
+
+        try:
+            fmt = _detect_format(target)
+        except Exception:
+            fmt = "legacy"
+        append_event(
+            db,
+            event_type=(
+                EventType.BUNDLE_IMPORTED if fmt == "bundle" else EventType.SNAPSHOT_IMPORTED
+            ),
+            payload={
+                "loaded": result.loaded,
+                "skipped_dupes": result.skipped_dupes,
+                "path": target,
+                "format": fmt,
+            },
+        )
         return {
             "loaded": result.loaded,
             "skipped_dupes": result.skipped_dupes,
@@ -603,6 +668,16 @@ def create_app(
                     status_code=400,
                     content={"error": "root_not_found", "message": str(err)},
                 )
+        append_event(
+            db,
+            event_type=EventType.BUNDLE_DISCOVERED,
+            payload={
+                "root": req.root,
+                "discovered": result.discovered,
+                "indexed": result.indexed,
+                "warnings": len(result.warnings),
+            },
+        )
         return {
             "discovered": result.discovered,
             "indexed": result.indexed,
@@ -653,6 +728,79 @@ def create_app(
 
         db: MemoryDB = _state["db"]
         report = await asyncio.to_thread(check_hygiene, db, base_dir=_state.get("base_dir"))
+        # Record a summary event plus one event per error-severity warning so
+        # EMOS can detect store decay from the log without polling /v1/hygiene.
+        counts = {
+            "warning_count": len(report.warnings),
+            "error_count": sum(1 for w in report.warnings if w.severity == "error"),
+            "warn_count": sum(1 for w in report.warnings if w.severity == "warn"),
+            "info_count": sum(1 for w in report.warnings if w.severity == "info"),
+        }
+        append_event(
+            db,
+            event_type=EventType.HYGIENE_CHECKED,
+            payload=counts,
+        )
+        for w in report.warnings:
+            if w.severity != "error":
+                continue
+            append_event(
+                db,
+                event_type=EventType.HYGIENE_WARNING,
+                memory_id=w.detail.get("memory_id"),
+                payload={
+                    "category": w.category,
+                    "severity": w.severity,
+                    "message": w.message,
+                    "source_uri": w.detail.get("source_uri"),
+                    "identifier": w.detail.get("identifier"),
+                },
+            )
         return report.to_dict()
+
+    @app.get("/v1/events")
+    async def list_events(
+        memory_id: str | None = None,
+        namespace: str | None = None,
+        event_type: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        after_seq: int | None = None,
+        before_seq: int | None = None,
+        limit: int = 100,
+        order: str = "asc",
+    ):
+        """List local lifecycle events with filtering and deterministic pagination.
+
+        Events are append-only local metadata — this endpoint never triggers
+        file hydration. Ordering is deterministic via the monotonic ``seq``
+        column. Use ``after_seq`` / ``before_seq`` for cursor-based pagination.
+        """
+        db: MemoryDB = _state["db"]
+        if order not in ("asc", "desc"):
+            raise HTTPException(status_code=400, detail="order must be 'asc' or 'desc'")
+        if limit < 1 or limit > 1000:
+            raise HTTPException(
+                status_code=400, detail="limit must be between 1 and 1000"
+            )
+        with Timer() as t:
+            listing = query_events(
+                db,
+                memory_id=memory_id,
+                namespace=namespace,
+                event_type=event_type,
+                since=since,
+                until=until,
+                after_seq=after_seq,
+                before_seq=before_seq,
+                limit=limit,
+                ascending=(order == "asc"),
+            )
+        return {
+            "events": listing["events"],
+            "count": listing["count"],
+            "next_seq": listing["next_seq"],
+            "trace_ms": round(t.ms, 2),
+        }
 
     return app

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -214,7 +214,7 @@ def test_v2_migration_opens_v01_db(tmp_path):
             assert col in columns, f"missing v2 column: {col}"
 
         version = db._conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 2
+        assert version == 3  # bumped to 3 by #41 (events table)
 
         row = db.all_rows()[0]
         assert row["id"] == "legacy1"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -257,8 +257,7 @@ def test_migration_adds_events_table(tmp_path: Path):
     db = MemoryDB(db_path)
     try:
         tables = {
-            row[0]
-            for row in db._conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            row[0] for row in db._conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
         }
         assert "events" in tables
         # Queries against the empty log succeed.
@@ -357,15 +356,11 @@ def test_events_endpoint_lists_created(client_with_events: TestClient):
 
 
 def test_events_endpoint_filter_by_event_type(client_with_events: TestClient):
-    resp = client_with_events.get(
-        "/v1/events", params={"event_type": EventType.MEMORY_CREATED}
-    )
+    resp = client_with_events.get("/v1/events", params={"event_type": EventType.MEMORY_CREATED})
     assert resp.status_code == 200
     assert resp.json()["count"] == 2
 
-    resp = client_with_events.get(
-        "/v1/events", params={"event_type": EventType.MEMORY_PROMOTION}
-    )
+    resp = client_with_events.get("/v1/events", params={"event_type": EventType.MEMORY_PROMOTION})
     assert resp.status_code == 200
     assert resp.json()["count"] == 0
 
@@ -374,9 +369,7 @@ def test_events_endpoint_pagination(client_with_events: TestClient):
     first = client_with_events.get("/v1/events", params={"limit": 1}).json()
     assert first["count"] == 1
     next_seq = first["next_seq"]
-    second = client_with_events.get(
-        "/v1/events", params={"limit": 1, "after_seq": next_seq}
-    ).json()
+    second = client_with_events.get("/v1/events", params={"limit": 1, "after_seq": next_seq}).json()
     assert second["count"] == 1
     assert second["events"][0]["seq"] > first["events"][0]["seq"]
 
@@ -469,15 +462,11 @@ def test_hygiene_emits_summary_and_warning_events(tmp_path: Path, fixture_file: 
 
         c.get("/v1/hygiene")
 
-        summary = c.get(
-            "/v1/events", params={"event_type": EventType.HYGIENE_CHECKED}
-        ).json()
+        summary = c.get("/v1/events", params={"event_type": EventType.HYGIENE_CHECKED}).json()
         assert summary["count"] == 1
         assert summary["events"][0]["payload"]["error_count"] >= 1
 
-        warnings = c.get(
-            "/v1/events", params={"event_type": EventType.HYGIENE_WARNING}
-        ).json()
+        warnings = c.get("/v1/events", params={"event_type": EventType.HYGIENE_WARNING}).json()
         assert warnings["count"] >= 1
         warn = warnings["events"][0]
         assert warn["payload"]["category"] == "missing_backing_file"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,522 @@
+"""Tests for #41 — append-only event log and /v1/events.
+
+Covers:
+    - Append + query basic ordering
+    - Filters (memory_id, namespace, event_type, time range)
+    - Deterministic ordering across interleaved appends
+    - Cursor pagination (after_seq / before_seq, asc/desc)
+    - Regression: existing /v1/add and /v1/search response shapes unchanged
+    - Migration: events table is added to an existing v1/v2 SQLite DB
+    - Event reads never trigger file hydration (SpyAdapter)
+    - File-backed and bundle imports emit the right events
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hotmem.db import MemoryDB
+from hotmem.events import EventType, append_event, query_events
+from hotmem.storage.local import LocalFilesystemAdapter
+
+# ── Unit-level append + query ─────────────────────────────────────────────
+
+
+def test_append_and_query_basic(tmp_db: MemoryDB):
+    e1 = append_event(
+        tmp_db,
+        event_type=EventType.MEMORY_CREATED,
+        memory_id="m1",
+        payload={"memory_type": "fact", "identifier": "u1", "content_hash": "h1"},
+        occurred_at="2026-07-13T00:00:00Z",
+    )
+    e2 = append_event(
+        tmp_db,
+        event_type=EventType.MEMORY_PROMOTION,
+        memory_id="m1",
+        payload={"from": "HOT", "to": "READY"},
+        occurred_at="2026-07-13T00:00:01Z",
+    )
+
+    listing = query_events(tmp_db)
+    assert listing["count"] == 2
+    seqs = [e["seq"] for e in listing["events"]]
+    assert seqs == [e1["seq"], e2["seq"]]
+    assert seqs[0] < seqs[1], "seq must be monotonic"
+    # Stable event identifiers are present and unique.
+    ids = {e["event_id"] for e in listing["events"]}
+    assert len(ids) == 2
+    assert all(len(i) == 32 for i in ids)
+    # Payloads round-trip as dicts.
+    assert listing["events"][0]["payload"]["identifier"] == "u1"
+    assert listing["events"][1]["payload"]["from"] == "HOT"
+
+
+def test_filter_by_memory_id(tmp_db: MemoryDB):
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id="m1")
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id="m2")
+    append_event(tmp_db, event_type=EventType.MEMORY_PROMOTION, memory_id="m1")
+
+    listing = query_events(tmp_db, memory_id="m1")
+    assert listing["count"] == 2
+    assert all(e["memory_id"] == "m1" for e in listing["events"])
+
+
+def test_filter_by_namespace(tmp_db: MemoryDB):
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED, namespace="contracts")
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED, namespace="billing")
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED, namespace="contracts")
+
+    listing = query_events(tmp_db, namespace="contracts")
+    assert listing["count"] == 2
+    assert all(e["namespace"] == "contracts" for e in listing["events"])
+
+
+def test_filter_by_event_type(tmp_db: MemoryDB):
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id="m1")
+    append_event(tmp_db, event_type=EventType.MEMORY_PROMOTION, memory_id="m1")
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id="m2")
+
+    listing = query_events(tmp_db, event_type=EventType.MEMORY_PROMOTION)
+    assert listing["count"] == 1
+    assert listing["events"][0]["event_type"] == EventType.MEMORY_PROMOTION
+
+
+def test_filter_by_time_range(tmp_db: MemoryDB):
+    append_event(
+        tmp_db,
+        event_type=EventType.MEMORY_CREATED,
+        occurred_at="2026-07-13T00:00:00Z",
+    )
+    append_event(
+        tmp_db,
+        event_type=EventType.MEMORY_CREATED,
+        occurred_at="2026-07-13T12:00:00Z",
+    )
+    append_event(
+        tmp_db,
+        event_type=EventType.MEMORY_CREATED,
+        occurred_at="2026-07-14T00:00:00Z",
+    )
+
+    listing = query_events(
+        tmp_db,
+        since="2026-07-13T06:00:00Z",
+        until="2026-07-13T23:59:59Z",
+    )
+    assert listing["count"] == 1
+    assert listing["events"][0]["occurred_at"] == "2026-07-13T12:00:00Z"
+
+
+# ── Pagination + deterministic ordering ──────────────────────────────────
+
+
+def test_pagination_after_seq_forward(tmp_db: MemoryDB):
+    seqs = []
+    for i in range(5):
+        e = append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id=f"m{i}")
+        seqs.append(e["seq"])
+
+    page1 = query_events(tmp_db, limit=2)
+    assert page1["count"] == 2
+    assert [e["seq"] for e in page1["events"]] == seqs[:2]
+    assert page1["next_seq"] == seqs[1]
+
+    page2 = query_events(tmp_db, limit=2, after_seq=page1["next_seq"])
+    assert [e["seq"] for e in page2["events"]] == seqs[2:4]
+    assert page2["next_seq"] == seqs[3]
+
+    page3 = query_events(tmp_db, limit=2, after_seq=page2["next_seq"])
+    assert [e["seq"] for e in page3["events"]] == [seqs[4]]
+    assert page3["next_seq"] == seqs[4]
+
+    # Empty page beyond the end returns next_seq of the last element seen
+    # would be seqs[4]; here we ask after it, so result is empty + null.
+    page4 = query_events(tmp_db, limit=2, after_seq=page3["next_seq"])
+    assert page4["count"] == 0
+    assert page4["next_seq"] is None
+
+
+def test_pagination_desc_with_before_seq(tmp_db: MemoryDB):
+    seqs = []
+    for i in range(4):
+        e = append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id=f"m{i}")
+        seqs.append(e["seq"])
+
+    page1 = query_events(tmp_db, limit=2, ascending=False)
+    assert [e["seq"] for e in page1["events"]] == [seqs[3], seqs[2]]
+    # Cursor is the last item in display order (smallest seq in this window).
+    assert page1["next_seq"] == seqs[2]
+
+    page2 = query_events(tmp_db, limit=2, ascending=False, before_seq=page1["next_seq"])
+    assert [e["seq"] for e in page2["events"]] == [seqs[1], seqs[0]]
+    assert page2["next_seq"] == seqs[0]
+
+
+def test_deterministic_order_across_interleaved_inserts(tmp_db: MemoryDB):
+    """Two logical clients appending sequentially must observe monotonic seqs.
+
+    SQLite AUTOINCREMENT guarantees strictly increasing seq across commits, so
+    interleaved appends from any number of MemoryDB connections on the same DB
+    produce a total order. We simulate this with sequential calls on the same
+    connection (the sidecar's single-writer model).
+    """
+    seqs = []
+    for i in range(10):
+        e = append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id=f"m{i}")
+        seqs.append(e["seq"])
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == 10
+
+
+# ── Regression: existing /v1/* response shapes unchanged ─────────────────
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    from hotmem.server import create_app
+
+    db_path = tmp_path / "test.sqlite"
+    app = create_app(db_path=db_path)
+    with TestClient(app) as c:
+        yield c
+
+
+def test_regression_add_response_unchanged(client: TestClient):
+    resp = client.post(
+        "/v1/add",
+        json={"identifier": "vendor_x", "fact": "Invoice total was $5000"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data.keys()) == {"memory_id", "content_hash", "trace_ms"}
+
+
+def test_regression_search_response_unchanged(client: TestClient):
+    client.post("/v1/add", json={"identifier": "a", "fact": "duplicate invoice risk for vendor x"})
+    resp = client.post("/v1/search", json={"query": "duplicate invoice", "top_k": 2})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data.keys()) == {"memories", "count", "trace_ms"}
+
+
+def test_regression_hydrate_response_unchanged(client: TestClient, tmp_path: Path):
+    # Snapshot then hydrate; response keys must remain {loaded, skipped_dupes, path}.
+    swap = tmp_path / "swap.jsonl"
+    snap = client.post("/v1/snapshot", json={"path": str(swap)})
+    assert snap.status_code == 200
+    assert set(snap.json().keys()) == {"exported", "path"}
+
+    hyd = client.post("/v1/hydrate", json={"path": str(swap)})
+    assert hyd.status_code == 200
+    assert set(hyd.json().keys()) == {"loaded", "skipped_dupes", "path"}
+
+
+def test_regression_discover_response_unchanged(client: TestClient, tmp_path: Path):
+    root = tmp_path / "bundles"
+    root.mkdir()
+    resp = client.post("/v1/discover", json={"root": str(root)})
+    assert resp.status_code == 200
+    assert set(resp.json().keys()) == {"discovered", "indexed", "warnings", "trace_ms"}
+
+
+def test_regression_hygiene_response_unchanged(client: TestClient):
+    resp = client.get("/v1/hygiene")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "warnings" in data and "stats" in data
+    assert set(data.keys()) >= {"warnings", "stats", "warning_count"}
+
+
+# ── Migration: existing SQLite DB gets the events table ──────────────────
+
+
+def test_migration_adds_events_table(tmp_path: Path):
+    """An existing v2 DB (no events table) is migrated to include events."""
+    db_path = tmp_path / "v2.sqlite"
+    conn = sqlite3.connect(db_path)
+    # Minimal v2 schema with the columns the _SCHEMA indexes/triggers reference.
+    conn.execute(
+        """CREATE TABLE memories (
+            id TEXT PRIMARY KEY,
+            identifier TEXT NOT NULL,
+            fact_text TEXT,
+            embedding BLOB,
+            content_hash TEXT DEFAULT '',
+            created_at TEXT
+        )"""
+    )
+    conn.execute("PRAGMA user_version = 2")
+    conn.commit()
+    conn.close()
+
+    db = MemoryDB(db_path)
+    try:
+        tables = {
+            row[0]
+            for row in db._conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        assert "events" in tables
+        # Queries against the empty log succeed.
+        listing = query_events(db)
+        assert listing["count"] == 0
+        assert listing["next_seq"] is None
+        # Existing memories count is unaffected.
+        assert db.count() == 0
+        # user_version bumped to 3.
+        version = db._conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 3
+    finally:
+        db.close()
+
+
+def test_migration_is_idempotent_for_events(tmp_path: Path):
+    db_path = tmp_path / "v3.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA user_version = 3")
+    conn.commit()
+    conn.close()
+    # Opening again must not error and must keep user_version at 3.
+    db = MemoryDB(db_path)
+    try:
+        version = db._conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 3
+    finally:
+        db.close()
+
+
+# ── Zero file reads during event reads (SpyAdapter) ───────────────────────
+
+
+def test_event_query_zero_file_reads(tmp_db: MemoryDB, fixture_file: Path):
+    """Querying events for a file-backed memory must not read backing bytes."""
+    from spy import SpyAdapter
+
+    spy = SpyAdapter(LocalFilesystemAdapter())
+    import hotmem.memory as mem_mod
+
+    orig = mem_mod.get_adapter
+    mem_mod.get_adapter = lambda uri: spy
+    try:
+        from hotmem.memory import FileRef, add_file_backed
+
+        ref = FileRef(
+            source_uri=str(fixture_file),
+            byte_offset=0,
+            byte_length=20,
+            source_format="bin",
+        )
+        mid, _ = add_file_backed(tmp_db, identifier="ds", file_ref=ref, summary="s")
+        # add_file_backed stats the file (exists check) but does NOT read it.
+        reads_after_add = spy.total_file_reads
+        assert reads_after_add == 0, "add_file_backed must not read backing bytes"
+
+        append_event(
+            tmp_db,
+            event_type=EventType.MEMORY_CREATED,
+            memory_id=mid,
+            payload={"memory_type": "file", "source_uri": str(fixture_file)},
+        )
+        listing = query_events(tmp_db, memory_id=mid)
+        assert listing["count"] == 1
+        # Event query must not have added any file reads.
+        assert spy.total_file_reads == 0, "event query must not trigger file hydration"
+    finally:
+        mem_mod.get_adapter = orig
+
+
+# ── HTTP /v1/events endpoint ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def client_with_events(tmp_path: Path):
+    from hotmem.server import create_app
+
+    db_path = tmp_path / "test.sqlite"
+    app = create_app(db_path=db_path)
+    with TestClient(app) as c:
+        c.post("/v1/add", json={"identifier": "u1", "fact": "first fact"})
+        c.post("/v1/add", json={"identifier": "u2", "fact": "second fact"})
+        yield c
+
+
+def test_events_endpoint_lists_created(client_with_events: TestClient):
+    resp = client_with_events.get("/v1/events")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"events", "count", "next_seq", "trace_ms"}
+    # Two add calls each emit memory.created; hygiene was not invoked here.
+    types = [e["event_type"] for e in body["events"]]
+    assert types == [EventType.MEMORY_CREATED, EventType.MEMORY_CREATED]
+    assert body["count"] == 2
+    assert body["next_seq"] is not None
+
+
+def test_events_endpoint_filter_by_event_type(client_with_events: TestClient):
+    resp = client_with_events.get(
+        "/v1/events", params={"event_type": EventType.MEMORY_CREATED}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 2
+
+    resp = client_with_events.get(
+        "/v1/events", params={"event_type": EventType.MEMORY_PROMOTION}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
+def test_events_endpoint_pagination(client_with_events: TestClient):
+    first = client_with_events.get("/v1/events", params={"limit": 1}).json()
+    assert first["count"] == 1
+    next_seq = first["next_seq"]
+    second = client_with_events.get(
+        "/v1/events", params={"limit": 1, "after_seq": next_seq}
+    ).json()
+    assert second["count"] == 1
+    assert second["events"][0]["seq"] > first["events"][0]["seq"]
+
+
+def test_events_endpoint_rejects_bad_order(client_with_events: TestClient):
+    resp = client_with_events.get("/v1/events", params={"order": "sideways"})
+    assert resp.status_code == 400
+
+
+def test_events_endpoint_rejects_bad_limit(client_with_events: TestClient):
+    resp = client_with_events.get("/v1/events", params={"limit": 0})
+    assert resp.status_code == 400
+    resp = client_with_events.get("/v1/events", params={"limit": 5000})
+    assert resp.status_code == 400
+
+
+def test_file_backed_add_emits_created_event(tmp_path: Path, fixture_file: Path):
+    """The file-backed add path emits memory.created with memory_type=file."""
+    from hotmem.server import create_app
+
+    mount = tmp_path / "mount"
+    mount.mkdir()
+    target = mount / fixture_file.name
+    target.write_bytes(fixture_file.read_bytes())
+    app = create_app(db_path=mount / "hotmem.sqlite", base_dir=mount)
+    with TestClient(app) as c:
+        resp = c.post(
+            "/v1/add",
+            json={
+                "identifier": "ds",
+                "file_uri": fixture_file.name,
+                "byte_offset": 0,
+                "byte_length": 20,
+                "source_format": "bin",
+                "summary": "slice",
+            },
+        )
+        assert resp.status_code == 200
+        mid = resp.json()["memory_id"]
+
+        events = c.get("/v1/events", params={"memory_id": mid}).json()
+        assert events["count"] == 1
+        ev = events["events"][0]
+        assert ev["event_type"] == EventType.MEMORY_CREATED
+        assert ev["payload"]["memory_type"] == "file"
+        assert ev["payload"]["source_uri"] == fixture_file.name
+        assert ev["payload"]["byte_length"] == 20
+
+
+def test_snapshot_hydrate_emits_imported_event(client_with_events: TestClient, tmp_path: Path):
+    swap = tmp_path / "swap.jsonl"
+    snap = client_with_events.post("/v1/snapshot", json={"path": str(swap)})
+    assert snap.status_code == 200
+    # Hydrate into the same DB; dupes skipped, but an import event is recorded.
+    hyd = client_with_events.post("/v1/hydrate", json={"path": str(swap)})
+    assert hyd.status_code == 200
+
+    events = client_with_events.get(
+        "/v1/events", params={"event_type": EventType.SNAPSHOT_IMPORTED}
+    ).json()
+    assert events["count"] == 1
+    ev = events["events"][0]
+    assert ev["payload"]["path"] == str(swap)
+    assert ev["payload"]["format"] == "legacy"
+
+
+def test_hygiene_emits_summary_and_warning_events(tmp_path: Path, fixture_file: Path):
+    """Hygiene emits one hygiene.checked summary plus one hygiene.warning per error."""
+    from hotmem.server import create_app
+
+    mount = tmp_path / "mount"
+    mount.mkdir()
+    target = mount / fixture_file.name
+    target.write_bytes(fixture_file.read_bytes())
+    app = create_app(db_path=mount / "hotmem.sqlite", base_dir=mount)
+    with TestClient(app) as c:
+        # Add a file-backed memory then delete its backing file -> error.
+        resp = c.post(
+            "/v1/add",
+            json={
+                "identifier": "ds",
+                "file_uri": fixture_file.name,
+                "byte_offset": 0,
+                "byte_length": 20,
+                "source_format": "bin",
+            },
+        )
+        mid = resp.json()["memory_id"]
+        target.unlink()
+
+        c.get("/v1/hygiene")
+
+        summary = c.get(
+            "/v1/events", params={"event_type": EventType.HYGIENE_CHECKED}
+        ).json()
+        assert summary["count"] == 1
+        assert summary["events"][0]["payload"]["error_count"] >= 1
+
+        warnings = c.get(
+            "/v1/events", params={"event_type": EventType.HYGIENE_WARNING}
+        ).json()
+        assert warnings["count"] >= 1
+        warn = warnings["events"][0]
+        assert warn["payload"]["category"] == "missing_backing_file"
+        assert warn["memory_id"] == mid
+
+
+# ── Retention helpers (unexposed) ─────────────────────────────────────────
+
+
+def test_trim_events_before_seq(tmp_db: MemoryDB):
+    for i in range(5):
+        append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id=f"m{i}")
+    deleted = tmp_db.trim_events_before_seq(3)
+    assert deleted == 2
+    remaining = query_events(tmp_db)
+    assert remaining["count"] == 3
+    assert all(e["seq"] >= 3 for e in remaining["events"])
+
+
+def test_trim_events_by_count(tmp_db: MemoryDB):
+    for i in range(5):
+        append_event(tmp_db, event_type=EventType.MEMORY_CREATED, memory_id=f"m{i}")
+    deleted = tmp_db.trim_events_by_count(keep=2)
+    assert deleted == 3
+    remaining = query_events(tmp_db)
+    assert remaining["count"] == 2
+    # Kept the most recent two.
+    seqs = [e["seq"] for e in remaining["events"]]
+    assert max(seqs) == 5
+
+
+def test_trim_events_by_count_zero_clears(tmp_db: MemoryDB):
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED)
+    append_event(tmp_db, event_type=EventType.MEMORY_CREATED)
+    deleted = tmp_db.trim_events_by_count(keep=0)
+    assert deleted == 2
+    assert query_events(tmp_db)["count"] == 0
+
+
+def test_trim_events_by_count_negative_rejected(tmp_db: MemoryDB):
+    with pytest.raises(ValueError):
+        tmp_db.trim_events_by_count(keep=-1)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -118,9 +118,7 @@ def test_migration_adds_events_table(v1_db_path: Path):
     db = MemoryDB(v1_db_path)
     try:
         tables = {
-            row[0] for row in db._conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            )
+            row[0] for row in db._conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
         }
         assert "events" in tables
         # The event log starts empty; no backfill of historical rows.

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -111,3 +111,22 @@ def test_file_backed_insert_works_on_migrated_db(v1_db_path: Path):
     assert got["byte_offset"] == 0
     assert got["byte_length"] == 100
     assert got["source_checksum"] == "abc"
+
+
+def test_migration_adds_events_table(v1_db_path: Path):
+    """#41: an existing v1 DB is migrated to include the append-only events table."""
+    db = MemoryDB(v1_db_path)
+    try:
+        tables = {
+            row[0] for row in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert "events" in tables
+        # The event log starts empty; no backfill of historical rows.
+        rows = db._conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        assert rows == 0
+        # user_version bumped to 3.
+        assert db._conn.execute("PRAGMA user_version").fetchone()[0] == 3
+    finally:
+        db.close()


### PR DESCRIPTION
Closes #41.

## Summary
Adds a local, append-only event log that records memory lifecycle and store signals as side effects of existing actions, without changing any existing `/v1/*` default response shape. Retention is local and explicit; no remote event infrastructure. EMOS owns policy, workflows, approvals, remote storage, and orchestration — HotMem only records local, append-only facts.

## Changes
- **`events` SQLite table** (idempotent `CREATE` in `_SCHEMA`) with monotonic `seq` AUTOINCREMENT PK and a stable client-facing `event_id` (UUID4 hex). Deterministic ordering; cursor pagination via `after_seq`/`before_seq`. Migration bumps `PRAGMA user_version` to 3; existing DBs operate without historical backfill.
- **`src/hotmem/events.py`**: `EventType` constants, `append_event`, `query_events`. Payload contract documented per `event_type` (free-form dict, `sort_keys=True` for stable diffability).
- **Emission wired into**: inline add, file-backed add, snapshot/bundle hydrate (lifespan auto-hydrate + `/v1/hydrate`), `/v1/discover`, and `/v1/hygiene` (one `hygiene.checked` summary plus one `hygiene.warning` per error severity).
- **`GET /v1/events`** with filters (`memory_id`, `namespace`, `event_type`, `since`/`until` time range) and deterministic cursor pagination. Pure SQL read path — never triggers file hydration.
- **Unexposed retention helpers** (`trim_events_before_seq`, `trim_events_by_count`) for local pruning; no API surface in this ticket.

## Event types
`memory.created`, `memory.updated`, `memory.provenance_changed`, `memory.promotion`, `memory.candidate`, `snapshot.imported`, `bundle.imported`, `bundle.discovered`, `hygiene.checked`, `hygiene.warning`. Payload shapes documented in `src/hotmem/events.py`.

## Compatibility guardrails (per issue)
- No existing `/v1/*` default payload shape changes (regression tests assert exact key sets for `/v1/add`, `/v1/search`, `/v1/hydrate`, `/v1/discover`, `/v1/hygiene`).
- Existing data operates without historical backfill; the migration is additive.
- Event reads never trigger file hydration (asserted via `SpyAdapter`).
- SQLite + filesystem/manifests remain canonical; events are durable local metadata, not a distributed log.
- No public write endpoint — events are append-only via internal actions.

## Tests (`tests/test_events.py`, 28 tests)
- Append + query basic ordering; stable `event_id` uniqueness; payload round-trip.
- Filters: `memory_id`, `namespace`, `event_type`, `since`/`until` time range.
- Deterministic ordering across interleaved appends (monotonic `seq`).
- Cursor pagination: `after_seq` forward, `before_seq` + `ascending=False` backward, `next_seq` cursor semantics, empty-page `null` cursor.
- Regression: exact response-shape assertions for `/v1/add`, `/v1/search`, `/v1/snapshot`, `/v1/hydrate`, `/v1/discover`, `/v1/hygiene`.
- Migration: v2 fixture DB acquires the `events` table + `user_version=3`; idempotent on a v3 DB.
- Zero-file-read assertion via `SpyAdapter` around file-backed add + event query.
- File-backed add emits `memory.created` with `memory_type=file` payload.
- Snapshot hydrate emits `snapshot.imported` with `format=legacy`.
- Hygiene emits `hygiene.checked` summary + `hygiene.warning` per error.
- Retention helpers: `trim_events_before_seq`, `trim_events_by_count` (incl. `keep=0` clears, negative rejected).
- Extended `tests/test_migration.py`: v1 fixture acquires `events` table, no backfill.
- Updated `tests/test_db.py`: `user_version` assertion bumped to 3.

## Verification
- `ruff check src/ tests/` — clean.
- `pytest` — all existing golden tests pass without modification (single intentional edit: `user_version == 2` → `3`).
- New tests green.

## Definition of done (from issue)
- [x] Relevant memory actions append events without changing existing endpoint responses.
- [x] Events can be filtered by memory id, namespace, event type, and time range.
- [x] Event ordering and pagination are deterministic.
- [x] Existing data can operate without historical backfill; migration is additive.
- [x] Event reads never trigger file hydration.
- [x] Append, filter, pagination, deterministic-order tests.
- [x] Regression tests for existing API response shapes.
- [x] Migration test for an existing SQLite database.
- [x] File-backed and bundle-backed events prove zero content reads.