### PR TITLE
feat: promotion lifecycle, signal only (#42)

### DIFF
--- a/src/hotmem/cli.py
+++ b/src/hotmem/cli.py
@@ -487,3 +487,56 @@ def import_cmd(source: str, source_db: str, target_db: str | None, swap_out: str
         # Remove the temp dir if empty (kept artifacts may live elsewhere).
         if os.path.isdir(tmp_dir) and not os.listdir(tmp_dir):
             os.rmdir(tmp_dir)
+
+
+@main.command()
+@click.option("--db", "db_path", required=True, type=click.Path(), help="Database path.")
+@click.option("--memory-id", "memory_id", required=True, help="Memory ID to promote.")
+@click.option("--to", "to_state", required=True, help="Target state: HOT|READY|PROMOTED|ARCHIVED.")
+@click.option("--reason", default=None, help="Optional reason for the transition.")
+@click.option("--actor", default=None, help="Optional actor performing the transition.")
+def promote(db_path: str, memory_id: str, to_state: str, reason: str | None, actor: str | None):
+    """Apply one promotion lifecycle transition (HOT→READY→PROMOTED→ARCHIVED)."""
+    from hotmem.db import MemoryDB
+    from hotmem.lifecycle import InvalidTransitionError, transition
+
+    db = MemoryDB(db_path)
+    try:
+        result = transition(db, memory_id, to_state, reason=reason, actor=actor)
+    except KeyError:
+        click.echo(f"Memory not found: {memory_id}", err=True)
+        raise SystemExit(1) from None
+    except InvalidTransitionError as err:
+        click.echo(str(err), err=True)
+        raise SystemExit(1) from err
+    except ValueError as err:
+        click.echo(str(err), err=True)
+        raise SystemExit(1) from err
+    finally:
+        db.close()
+    click.echo(
+        f"{result['memory_id']}: {result['promotion_state']} (updated {result['updated_at']})"
+    )
+
+
+@main.command()
+@click.option("--db", "db_path", required=True, type=click.Path(), help="Database path.")
+@click.option("--namespace", default=None, help="Filter by namespace.")
+@click.option("--state", default=None, help="Filter by promotion state.")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def candidates(db_path: str, namespace: str | None, state: str | None, as_json: bool):
+    """List memories flagged as promotion candidates."""
+    from hotmem.db import MemoryDB
+    from hotmem.lifecycle import list_candidates
+
+    db = MemoryDB(db_path)
+    try:
+        rows = list_candidates(db, namespace=namespace, state=state)
+    finally:
+        db.close()
+
+    if as_json:
+        click.echo(json.dumps(rows, default=str, indent=2))
+    else:
+        for r in rows:
+            click.echo(f"{r['id']}\t{r['identifier']}\t{r.get('promotion_state', 'HOT')}")

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -487,12 +487,18 @@ class MemoryDB:
     # ── Promotion lifecycle (#42) ───────────────────────────────────────
 
     def update_promotion_state(
-        self, memory_id: str, state: str, *, updated_at: str | None = None
+        self,
+        memory_id: str,
+        state: str,
+        *,
+        updated_at: str | None = None,
+        _commit: bool = True,
     ) -> None:
         """Update promotion_state + updated_at on a memory row.
 
         Called by lifecycle.transition() after validating the transition.
-        Emits no event — the caller owns event emission.
+        ``_commit=False`` lets the caller batch the state update + event emit
+        in one transaction (atomicity). The caller must commit.
         """
         ts = updated_at or __import__("datetime").datetime.now(__import__("datetime").UTC).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
@@ -501,15 +507,19 @@ class MemoryDB:
             "UPDATE memories SET promotion_state = ?, updated_at = ? WHERE id = ?",
             (state, ts, memory_id),
         )
-        self._conn.commit()
+        if _commit:
+            self._conn.commit()
 
-    def set_promotion_candidate(self, memory_id: str, candidate: int) -> None:
+    def set_promotion_candidate(
+        self, memory_id: str, candidate: int, *, _commit: bool = True
+    ) -> None:
         """Set the promotion_candidate flag (0/1) on a memory row."""
         self._conn.execute(
             "UPDATE memories SET promotion_candidate = ? WHERE id = ?",
             (candidate, memory_id),
         )
-        self._conn.commit()
+        if _commit:
+            self._conn.commit()
 
     def list_promotion_candidates(
         self, *, namespace: str | None = None, state: str | None = None
@@ -611,6 +621,16 @@ class MemoryDB:
         """Remove all bundle index entries."""
         self._conn.execute("DELETE FROM bundle_index")
         self._conn.commit()
+
+    # ── Transaction control (#41/#42) ──────────────────────────────────
+
+    def commit(self) -> None:
+        """Commit the current transaction (public batch-commit API)."""
+        self._conn.commit()
+
+    def rollback(self) -> None:
+        """Rollback the current transaction."""
+        self._conn.rollback()
 
     # ── Event log (#41) ────────────────────────────────────────────────
 
@@ -754,33 +774,45 @@ class MemoryDB:
         _trace.debug("insert_many", f"stored {inserted} memories", detail={"attempted": len(rows)})
         return inserted
 
-    def search_with_cosine(self, query_embedding: bytes) -> list[dict[str, Any]]:
-        """Return all memories with their cosine similarity to the query embedding."""
+    def search_with_cosine(
+        self, query_embedding: bytes, *, include_archived: bool = False
+    ) -> list[dict[str, Any]]:
+        """Return all memories with their cosine similarity to the query embedding.
+
+        Archived memories are excluded by default; pass ``include_archived=True``
+        for audit/full profiles.
+        """
+        archived_clause = "" if include_archived else " AND promotion_state != 'ARCHIVED'"
         rows = self._conn.execute(
             f"""SELECT id, identifier, fact_text, fact_summary, importance,
                       metadata_json, source, created_at,
                       cosine_sim(embedding, ?) AS cosine_score
-               FROM memories
-               WHERE {_ttl_live()}
-               ORDER BY cosine_score DESC""",
+                FROM memories
+                WHERE {_ttl_live()}{archived_clause}
+                ORDER BY cosine_score DESC""",
             (query_embedding,),
         ).fetchall()
         return [dict(r) for r in rows]
 
-    def fts_search(self, query: str) -> list[dict[str, Any]]:
-        """Return full-text matches with raw BM25 scores."""
+    def fts_search(self, query: str, *, include_archived: bool = False) -> list[dict[str, Any]]:
+        """Return full-text matches with raw BM25 scores.
+
+        Archived memories are excluded by default; pass ``include_archived=True``
+        for audit/full profiles.
+        """
         fts_query = _fts_query(query)
         if not fts_query:
             return []
 
+        archived_clause = "" if include_archived else " AND m.promotion_state != 'ARCHIVED'"
         rows = self._conn.execute(
             f"""SELECT m.id, m.identifier, m.fact_text, m.importance, m.metadata_json,
-                      m.source, m.created_at, bm25(memories_fts) AS bm25_score
-               FROM memories_fts
-               JOIN memories AS m ON m.rowid = memories_fts.rowid
-               WHERE memories_fts MATCH ?
-                 AND {_ttl_live("m.")}
-               ORDER BY bm25_score ASC""",
+                       m.source, m.created_at, bm25(memories_fts) AS bm25_score
+                FROM memories_fts
+                JOIN memories AS m ON m.rowid = memories_fts.rowid
+                WHERE memories_fts MATCH ?
+                  AND {_ttl_live("m.")}{archived_clause}
+                ORDER BY bm25_score ASC""",
             (fts_query,),
         ).fetchall()
         return [dict(r) for r in rows]

--- a/src/hotmem/db.py
+++ b/src/hotmem/db.py
@@ -484,6 +484,76 @@ class MemoryDB:
         ).fetchone()
         return dict(row) if row is not None else None
 
+    # ── Promotion lifecycle (#42) ───────────────────────────────────────
+
+    def update_promotion_state(
+        self, memory_id: str, state: str, *, updated_at: str | None = None
+    ) -> None:
+        """Update promotion_state + updated_at on a memory row.
+
+        Called by lifecycle.transition() after validating the transition.
+        Emits no event — the caller owns event emission.
+        """
+        ts = updated_at or __import__("datetime").datetime.now(__import__("datetime").UTC).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        self._conn.execute(
+            "UPDATE memories SET promotion_state = ?, updated_at = ? WHERE id = ?",
+            (state, ts, memory_id),
+        )
+        self._conn.commit()
+
+    def set_promotion_candidate(self, memory_id: str, candidate: int) -> None:
+        """Set the promotion_candidate flag (0/1) on a memory row."""
+        self._conn.execute(
+            "UPDATE memories SET promotion_candidate = ? WHERE id = ?",
+            (candidate, memory_id),
+        )
+        self._conn.commit()
+
+    def list_promotion_candidates(
+        self, *, namespace: str | None = None, state: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Return memories flagged as promotion candidates.
+
+        Pure DB read — no file hydration.
+        """
+        clauses = ["promotion_candidate = 1"]
+        params: list[Any] = []
+        if namespace is not None:
+            clauses.append("namespace = ?")
+            params.append(namespace)
+        if state is not None:
+            clauses.append("promotion_state = ?")
+            params.append(state)
+        where = " WHERE " + " AND ".join(clauses)
+        cols = ", ".join(_MEMORY_COLUMNS)
+        rows = self._conn.execute(
+            f"SELECT {cols} FROM memories{where} ORDER BY created_at",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def list_by_promotion_state(
+        self, state: str, *, namespace: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Return memories in a given promotion_state.
+
+        Pure DB read — no file hydration.
+        """
+        clauses = ["promotion_state = ?"]
+        params: list[Any] = [state]
+        if namespace is not None:
+            clauses.append("namespace = ?")
+            params.append(namespace)
+        where = " WHERE " + " AND ".join(clauses)
+        cols = ", ".join(_MEMORY_COLUMNS)
+        rows = self._conn.execute(
+            f"SELECT {cols} FROM memories{where} ORDER BY created_at",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
     def list_file_backed(self) -> list[dict[str, Any]]:
         """Return all file-backed memory rows (metadata only; no file I/O).
 

--- a/src/hotmem/events.py
+++ b/src/hotmem/events.py
@@ -55,6 +55,8 @@ class EventType:
     """Canonical event type strings. Stored as plain text for SQL introspection."""
 
     MEMORY_CREATED = "memory.created"
+    MEMORY_PROMOTION = "memory.promotion"
+    MEMORY_CANDIDATE = "memory.candidate"
     SNAPSHOT_IMPORTED = "snapshot.imported"
     BUNDLE_IMPORTED = "bundle.imported"
     BUNDLE_DISCOVERED = "bundle.discovered"

--- a/src/hotmem/lifecycle.py
+++ b/src/hotmem/lifecycle.py
@@ -123,7 +123,7 @@ def transition(
         raise InvalidTransitionError(memory_id, from_state, to_state)
 
     updated_at = _utc_now_iso()
-    db.update_promotion_state(memory_id, to_state, updated_at=updated_at)
+    db.update_promotion_state(memory_id, to_state, updated_at=updated_at, _commit=False)
 
     payload: dict[str, Any] = {"from": from_state, "to": to_state}
     if reason is not None:
@@ -139,7 +139,10 @@ def transition(
             namespace=namespace,
             payload=payload,
             occurred_at=updated_at,
+            _commit=False,
         )
+    # Single commit for state update + event emit (atomic: both or neither).
+    db.commit()
 
     _trace.info(
         "transition",
@@ -175,7 +178,7 @@ def mark_candidate(
         raise KeyError(f"memory not found: {memory_id}")
 
     namespace = record.get("namespace") or ""
-    db.set_promotion_candidate(memory_id, 1 if candidate else 0)
+    db.set_promotion_candidate(memory_id, 1 if candidate else 0, _commit=False)
 
     payload: dict[str, Any] = {"candidate": bool(candidate)}
     if reason is not None:
@@ -188,7 +191,10 @@ def mark_candidate(
             memory_id=memory_id,
             namespace=namespace,
             payload=payload,
+            _commit=False,
         )
+    # Single commit for candidate flag + event emit (atomic).
+    db.commit()
 
     _trace.info(
         "candidate",

--- a/src/hotmem/lifecycle.py
+++ b/src/hotmem/lifecycle.py
@@ -1,0 +1,235 @@
+"""HotMem lifecycle — promotion state and candidate signals (signal only).
+
+Purpose:
+     Add a local, explicit lifecycle state and promotion candidate signals
+     without turning HotMem into a policy engine. HotMem stores state,
+     transition metadata, and candidate signals, and emits promotion events
+     through the #41 event log. EMOS owns policy — whether, when, and where
+     promotion happens — and HotMem performs no automatic remote migration,
+     deletion, scheduling, approvals, or hierarchy protocol.
+
+State model:
+     HOT -> READY -> PROMOTED -> ARCHIVED
+
+     Transitions are strict forward-only linear. Any other transition
+     (including ARCHIVED -> HOT reheat, and same-state "transitions") raises
+     ``InvalidTransitionError`` and does not mutate state. EMOS may re-add a
+     new memory at HOT if it needs to revive an archived one — HotMem will not
+     rewind state on an existing record.
+
+Default behavior:
+     Existing memory records default to ``promotion_state="HOT"`` and
+     ``promotion_candidate=0`` (already in the v2 schema). No caller must
+     supply lifecycle fields; inline, file-backed, JSONL, and bundle memory
+     workflows remain compatible without changes.
+
+Interface:
+     PROMOTION_STATES, VALID_TRANSITIONS
+     InvalidTransitionError(memory_id, from_state, to_state)
+     transition(db, memory_id, to_state, *, reason=None, actor=None, emit_event=True) -> dict
+     mark_candidate(db, memory_id, candidate, *, reason=None, emit_event=True) -> dict
+     list_candidates(db, *, namespace=None, state=None) -> list[dict]
+     list_by_state(db, state, *, namespace=None) -> list[dict]
+
+Deps: hotmem.db, hotmem.events, hotmem.trace
+Extension: do NOT add policy, scheduling, approvals, or remote storage here.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any
+
+from hotmem.db import MemoryDB
+from hotmem.events import EventType, append_event
+from hotmem.trace import get_tracer
+
+_trace = get_tracer("lifecycle")
+
+PROMOTION_STATES: tuple[str, ...] = ("HOT", "READY", "PROMOTED", "ARCHIVED")
+
+VALID_TRANSITIONS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("HOT", "READY"),
+        ("READY", "PROMOTED"),
+        ("PROMOTED", "ARCHIVED"),
+    }
+)
+
+
+class InvalidTransitionError(Exception):
+    """Raised when a requested promotion transition is not in VALID_TRANSITIONS."""
+
+    def __init__(self, memory_id: str, from_state: str, to_state: str) -> None:
+        self.memory_id = memory_id
+        self.from_state = from_state
+        self.to_state = to_state
+        valid = sorted(f"{a}->{b}" for (a, b) in VALID_TRANSITIONS)
+        super().__init__(
+            f"invalid promotion transition for memory {memory_id}: "
+            f"{from_state} -> {to_state}; valid transitions: {valid}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        valid_targets = [b for (a, b) in VALID_TRANSITIONS if a == self.from_state]
+        return {
+            "error": "invalid_transition",
+            "memory_id": self.memory_id,
+            "from_state": self.from_state,
+            "to_state": self.to_state,
+            "valid": valid_targets,
+            "message": str(self),
+        }
+
+
+def _utc_now_iso() -> str:
+    return _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def transition(
+    db: MemoryDB,
+    memory_id: str,
+    to_state: str,
+    *,
+    reason: str | None = None,
+    actor: str | None = None,
+    emit_event: bool = True,
+) -> dict[str, Any]:
+    """Validate and apply one forward-only promotion transition.
+
+    Reads current state via ``get_memory`` (pure DB, no file hydration),
+    validates against ``VALID_TRANSITIONS``, raises ``InvalidTransitionError``
+    on any deviation, persists the new state + ``updated_at``, and (unless
+    ``emit_event`` is False) appends a ``memory.promotion`` event.
+
+    Returns a dict with the resulting ``promotion_state`` and ``updated_at``.
+
+    Raises:
+        KeyError: memory not found.
+        ValueError: ``to_state`` is not a known state.
+        InvalidTransitionError: the transition is not valid.
+    """
+    if to_state not in PROMOTION_STATES:
+        raise ValueError(f"unknown promotion state {to_state!r}; known: {list(PROMOTION_STATES)}")
+
+    record = db.get_memory(memory_id)
+    if record is None:
+        raise KeyError(f"memory not found: {memory_id}")
+
+    from_state = record.get("promotion_state") or "HOT"
+    namespace = record.get("namespace") or ""
+
+    if (from_state, to_state) not in VALID_TRANSITIONS:
+        raise InvalidTransitionError(memory_id, from_state, to_state)
+
+    updated_at = _utc_now_iso()
+    db.update_promotion_state(memory_id, to_state, updated_at=updated_at)
+
+    payload: dict[str, Any] = {"from": from_state, "to": to_state}
+    if reason is not None:
+        payload["reason"] = reason
+    if actor is not None:
+        payload["actor"] = actor
+
+    if emit_event:
+        append_event(
+            db,
+            event_type=EventType.MEMORY_PROMOTION,
+            memory_id=memory_id,
+            namespace=namespace,
+            payload=payload,
+            occurred_at=updated_at,
+        )
+
+    _trace.info(
+        "transition",
+        f"{memory_id[:8]}… {from_state} -> {to_state}",
+        detail={"memory_id": memory_id, "from": from_state, "to": to_state, "reason": reason},
+    )
+    return {
+        "memory_id": memory_id,
+        "promotion_state": to_state,
+        "updated_at": updated_at,
+    }
+
+
+def mark_candidate(
+    db: MemoryDB,
+    memory_id: str,
+    candidate: bool,
+    *,
+    reason: str | None = None,
+    emit_event: bool = True,
+) -> dict[str, Any]:
+    """Set the ``promotion_candidate`` flag on a memory, independent of state.
+
+    The candidate signal is decoupled from the state machine: it may be set on
+    a memory in any state, and it persists across transitions. Records a
+    ``memory.candidate`` event unless ``emit_event`` is False.
+
+    Raises:
+        KeyError: memory not found.
+    """
+    record = db.get_memory(memory_id)
+    if record is None:
+        raise KeyError(f"memory not found: {memory_id}")
+
+    namespace = record.get("namespace") or ""
+    db.set_promotion_candidate(memory_id, 1 if candidate else 0)
+
+    payload: dict[str, Any] = {"candidate": bool(candidate)}
+    if reason is not None:
+        payload["reason"] = reason
+
+    if emit_event:
+        append_event(
+            db,
+            event_type=EventType.MEMORY_CANDIDATE,
+            memory_id=memory_id,
+            namespace=namespace,
+            payload=payload,
+        )
+
+    _trace.info(
+        "candidate",
+        f"{memory_id[:8]}… candidate={bool(candidate)}",
+        detail={"memory_id": memory_id, "candidate": bool(candidate), "reason": reason},
+    )
+    return {
+        "memory_id": memory_id,
+        "promotion_candidate": 1 if candidate else 0,
+    }
+
+
+def list_candidates(
+    db: MemoryDB,
+    *,
+    namespace: str | None = None,
+    state: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return memories flagged as promotion candidates, optionally filtered.
+
+    Pure DB read — no file hydration. ``state`` filters on promotion_state.
+    """
+    return db.list_promotion_candidates(namespace=namespace, state=state)
+
+
+def list_by_state(
+    db: MemoryDB,
+    state: str,
+    *,
+    namespace: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return memories in a given promotion_state, optionally by namespace.
+
+    Pure DB read — no file hydration.
+    """
+    return db.list_by_promotion_state(state, namespace=namespace)
+
+
+def states_model() -> dict[str, Any]:
+    """Return the static lifecycle model for documentation endpoints."""
+    return {
+        "states": list(PROMOTION_STATES),
+        "valid_transitions": [list(t) for t in sorted(VALID_TRANSITIONS)],
+    }

--- a/src/hotmem/search.py
+++ b/src/hotmem/search.py
@@ -59,8 +59,13 @@ def search_memories(
     query: str,
     top_k: int = 5,
     max_chars: int | None = None,
+    *,
+    include_archived: bool = False,
 ) -> list[dict[str, Any]]:
     """Search memories and return ranked, LLM-ready message objects.
+
+    Archived memories are excluded by default; pass ``include_archived=True``
+    for audit/full profiles.
 
     Returns:
         List of dicts with keys: role, content, memory_id, identifier, score
@@ -71,8 +76,8 @@ def search_memories(
         query_blob = pack_embedding(query_vec)
 
         # Get all candidates with cosine scores from DB
-        candidates = db.search_with_cosine(query_blob)
-        fts_scores = _normalize_bm25(db.fts_search(query))
+        candidates = db.search_with_cosine(query_blob, include_archived=include_archived)
+        fts_scores = _normalize_bm25(db.fts_search(query, include_archived=include_archived))
 
         # Apply hybrid scoring
         scored = []

--- a/src/hotmem/server.py
+++ b/src/hotmem/server.py
@@ -33,6 +33,14 @@ from hotmem.db import MemoryDB
 from hotmem.embed import EMBEDDING_DIM, EMBEDDING_MODEL, embed_text, pack_embedding
 from hotmem.events import EventType, append_event, emit_import_event, query_events
 from hotmem.hygiene import check_hygiene
+from hotmem.lifecycle import (
+    InvalidTransitionError,
+    list_by_state,
+    list_candidates,
+    mark_candidate,
+    states_model,
+    transition,
+)
 from hotmem.memory import FileRef, add_file_backed, get_memory_metadata, hydrate_memory
 from hotmem.profiles import HydrationProfile, hydrate_with_profile
 from hotmem.provenance import ProvenanceError
@@ -170,6 +178,26 @@ class DiscoverRequest(BaseModel):
 
     root: str = Field(..., description="Root directory to scan for bundles")
     max_depth: int = Field(default=10, ge=1, le=50, description="Max directory depth")
+
+
+class PromoteRequest(BaseModel):
+    """Body for POST /v1/memory/{id}/promote — apply one lifecycle transition.
+
+    HotMem stores state and emits signals; EMOS owns policy. Only forward-only
+    transitions in HOT -> READY -> PROMOTED -> ARCHIVED are accepted; any other
+    transition returns 409 invalid_transition without mutating state.
+    """
+
+    to_state: str = Field(..., description="HOT | READY | PROMOTED | ARCHIVED")
+    reason: str | None = None
+    actor: str | None = None
+
+
+class CandidateRequest(BaseModel):
+    """Body for POST /v1/memory/{id}/candidate — set the promotion_candidate flag."""
+
+    candidate: bool = True
+    reason: str | None = None
 
 
 # ── Lifespan ─────────────────────────────────────────────────────────────────
@@ -774,6 +802,115 @@ def create_app(
             "events": listing["events"],
             "count": listing["count"],
             "next_seq": listing["next_seq"],
+            "trace_ms": round(t.ms, 2),
+        }
+
+    # ── Promotion lifecycle endpoints (#42, signal only) ────────────────
+
+    @app.post("/v1/memory/{memory_id}/promote")
+    async def promote_memory(memory_id: str, req: PromoteRequest):
+        """Apply one forward-only promotion transition.
+
+        HotMem stores state and emits a ``memory.promotion`` event; EMOS owns
+        policy. Returns 409 ``invalid_transition`` (without mutating state) for
+        any transition not in HOT -> READY -> PROMOTED -> ARCHIVED.
+        """
+        db: MemoryDB = _state["db"]
+        with Timer() as t:
+            try:
+                result = transition(
+                    db,
+                    memory_id,
+                    req.to_state,
+                    reason=req.reason,
+                    actor=req.actor,
+                )
+            except KeyError:
+                return JSONResponse(
+                    status_code=404,
+                    content={"error": "not_found", "memory_id": memory_id},
+                )
+            except InvalidTransitionError as err:
+                return JSONResponse(status_code=409, content=err.to_dict())
+        result["trace_ms"] = round(t.ms, 2)
+        return result
+
+    @app.post("/v1/memory/{memory_id}/candidate")
+    async def set_candidate(memory_id: str, req: CandidateRequest):
+        """Set the ``promotion_candidate`` flag on a memory (independent of state)."""
+        db: MemoryDB = _state["db"]
+        with Timer() as t:
+            try:
+                result = mark_candidate(
+                    db,
+                    memory_id,
+                    req.candidate,
+                    reason=req.reason,
+                )
+            except KeyError:
+                return JSONResponse(
+                    status_code=404,
+                    content={"error": "not_found", "memory_id": memory_id},
+                )
+        result["trace_ms"] = round(t.ms, 2)
+        return result
+
+    @app.get("/v1/promotion/candidates")
+    async def promotion_candidates(
+        namespace: str | None = None,
+        state: str | None = None,
+    ):
+        """List memories flagged as promotion candidates (pure DB read)."""
+        db: MemoryDB = _state["db"]
+        with Timer() as t:
+            rows = list_candidates(db, namespace=namespace, state=state)
+        candidates = [
+            {
+                "memory_id": r["id"],
+                "identifier": r["identifier"],
+                "namespace": r.get("namespace") or "",
+                "promotion_state": r.get("promotion_state") or "HOT",
+                "memory_type": r.get("memory_type") or "fact",
+                "created_at": r.get("created_at"),
+            }
+            for r in rows
+        ]
+        return {
+            "candidates": candidates,
+            "count": len(candidates),
+            "trace_ms": round(t.ms, 2),
+        }
+
+    @app.get("/v1/promotion/states")
+    async def promotion_states():
+        """Return the static lifecycle model: states and valid transitions."""
+        return states_model()
+
+    @app.get("/v1/promotion/by-state")
+    async def promotion_by_state(
+        state: str,
+        namespace: str | None = None,
+    ):
+        """List memories in a given promotion_state (pure DB read)."""
+        db: MemoryDB = _state["db"]
+        with Timer() as t:
+            rows = list_by_state(db, state, namespace=namespace)
+        summaries = [
+            {
+                "memory_id": r["id"],
+                "identifier": r["identifier"],
+                "namespace": r.get("namespace") or "",
+                "promotion_state": r.get("promotion_state") or "HOT",
+                "promotion_candidate": bool(r.get("promotion_candidate") or 0),
+                "memory_type": r.get("memory_type") or "fact",
+                "created_at": r.get("created_at"),
+                "updated_at": r.get("updated_at"),
+            }
+            for r in rows
+        ]
+        return {
+            "memories": summaries,
+            "count": len(summaries),
             "trace_ms": round(t.ms, 2),
         }
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,532 @@
+"""Tests for #42 — promotion lifecycle (signal only).
+
+Covers:
+    - Valid forward transitions HOT -> READY -> PROMOTED -> ARCHIVED
+    - Invalid transitions return errors and do not mutate state
+    - Same-state transitions are invalid
+    - Default-state backward compatibility for existing records
+    - Inline, file-backed, JSONL, and bundle workflows remain compatible
+    - Candidate signal is independent of state and persists across transitions
+    - Event emission integration with #41
+    - API + CLI compatibility when lifecycle fields are omitted
+    - /v1/promotion/states, /v1/promotion/candidates, /v1/promotion/by-state
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hotmem.db import MemoryDB
+from hotmem.embed import embed_text, pack_embedding
+from hotmem.events import EventType, query_events
+from hotmem.lifecycle import (
+    PROMOTION_STATES,
+    VALID_TRANSITIONS,
+    InvalidTransitionError,
+    list_by_state,
+    list_candidates,
+    mark_candidate,
+    states_model,
+    transition,
+)
+
+# ── Valid transitions ─────────────────────────────────────────────────────
+
+
+def _add_inline(db: MemoryDB, mid: str = "m1", identifier: str = "u1") -> str:
+    blob = pack_embedding(embed_text("a fact"))
+    db.insert(id=mid, identifier=identifier, fact_text="a fact", embedding=blob)
+    return mid
+
+
+def test_valid_transitions_chained(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    r1 = transition(tmp_db, mid, "READY")
+    assert r1["promotion_state"] == "READY"
+    assert tmp_db.get_memory(mid)["promotion_state"] == "READY"
+    r2 = transition(tmp_db, mid, "PROMOTED")
+    assert r2["promotion_state"] == "PROMOTED"
+    r3 = transition(tmp_db, mid, "ARCHIVED")
+    assert r3["promotion_state"] == "ARCHIVED"
+    assert tmp_db.get_memory(mid)["promotion_state"] == "ARCHIVED"
+
+
+def test_transition_records_updated_at(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    result = transition(tmp_db, mid, "READY")
+    assert result["updated_at"] is not None
+    row = tmp_db.get_memory(mid)
+    assert row["updated_at"] == result["updated_at"]
+
+
+# ── Invalid transitions ───────────────────────────────────────────────────
+
+
+def test_invalid_skip_transition_raises_no_mutation(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    with pytest.raises(InvalidTransitionError) as exc_info:
+        transition(tmp_db, mid, "PROMOTED")  # HOT -> PROMOTED is a skip
+    err = exc_info.value
+    assert err.from_state == "HOT"
+    assert err.to_state == "PROMOTED"
+    assert err.to_dict()["valid"] == ["READY"]
+    # State must NOT have been mutated.
+    assert tmp_db.get_memory(mid)["promotion_state"] == "HOT"
+
+
+def test_invalid_archived_to_hot_reheat_raises(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    transition(tmp_db, mid, "READY")
+    transition(tmp_db, mid, "PROMOTED")
+    transition(tmp_db, mid, "ARCHIVED")
+    with pytest.raises(InvalidTransitionError):
+        transition(tmp_db, mid, "HOT")
+    assert tmp_db.get_memory(mid)["promotion_state"] == "ARCHIVED"
+
+
+def test_invalid_same_state_raises(tmp_db: MemoryDB):
+    """A transition to the same state is not a transition and is invalid."""
+    mid = _add_inline(tmp_db)
+    with pytest.raises(InvalidTransitionError):
+        transition(tmp_db, mid, "HOT")
+    assert tmp_db.get_memory(mid)["promotion_state"] == "HOT"
+
+
+def test_unknown_state_raises_value_error(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    with pytest.raises(ValueError):
+        transition(tmp_db, mid, "FROZEN")
+
+
+def test_transition_missing_memory_raises_keyerror(tmp_db: MemoryDB):
+    with pytest.raises(KeyError):
+        transition(tmp_db, "nonexistent", "READY")
+
+
+# ── Default-state backward compatibility ──────────────────────────────────
+
+
+def test_default_state_for_inline_insert(tmp_db: MemoryDB):
+    """An insert without lifecycle fields defaults to HOT / candidate=0."""
+    blob = pack_embedding(embed_text("plain fact"))
+    tmp_db.insert(id="d1", identifier="x", fact_text="plain fact", embedding=blob)
+    row = tmp_db.get_memory("d1")
+    assert row["promotion_state"] == "HOT"
+    assert row["promotion_candidate"] == 0
+
+
+def test_default_state_for_file_backed_insert(tmp_db: MemoryDB, fixture_file: Path):
+    tmp_db.insert_file_backed(
+        id="fb1",
+        identifier="ds",
+        source_uri=str(fixture_file),
+        byte_offset=0,
+        byte_length=20,
+        source_format="bin",
+        source_checksum=None,
+        fact_summary="slice",
+    )
+    row = tmp_db.get_memory("fb1")
+    assert row["promotion_state"] == "HOT"
+    assert row["promotion_candidate"] == 0
+
+
+def test_existing_v2_row_defaults_safe_after_migration(tmp_path: Path):
+    """A pre-existing memories row keeps HOT/0 defaults after the v3 migration."""
+    import sqlite3
+
+    db_path = tmp_path / "pre.sqlite"
+    conn = sqlite3.connect(db_path)
+    # Minimal schema with the columns the schema + indexes reference.
+    conn.execute(
+        """CREATE TABLE memories (
+            id TEXT PRIMARY KEY, identifier TEXT NOT NULL, fact_text TEXT,
+            embedding BLOB, embedding_dim INTEGER, embedding_model TEXT DEFAULT '',
+            source TEXT DEFAULT '', importance REAL DEFAULT 0.5,
+            metadata_json TEXT DEFAULT '{}', content_hash TEXT DEFAULT '',
+            ttl_seconds INTEGER, created_at TEXT,
+            promotion_state TEXT DEFAULT 'HOT',
+            promotion_candidate INTEGER DEFAULT 0
+        )"""
+    )
+    blob = pack_embedding(embed_text("legacy fact"))
+    conn.execute(
+        "INSERT INTO memories "
+        "(id, identifier, fact_text, embedding, promotion_state, promotion_candidate) "
+        "VALUES ('legacy1', 'x', 'legacy fact', ?, 'HOT', 0)",
+        (blob,),
+    )
+    conn.execute("PRAGMA user_version = 2")
+    conn.commit()
+    conn.close()
+
+    db = MemoryDB(db_path)
+    try:
+        row = db.get_memory("legacy1")
+        assert row["promotion_state"] == "HOT"
+        assert row["promotion_candidate"] == 0
+    finally:
+        db.close()
+
+
+# ── Workflow compatibility (inline / file-backed / JSONL / bundle) ────────
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    from hotmem.server import create_app
+
+    db_path = tmp_path / "test.sqlite"
+    app = create_app(db_path=db_path)
+    with TestClient(app) as c:
+        yield c
+
+
+def test_existing_inline_workflow_compat(client: TestClient):
+    """Adding an inline memory without lifecycle fields still works."""
+    resp = client.post("/v1/add", json={"identifier": "u1", "fact": "hello"})
+    assert resp.status_code == 200
+    mid = resp.json()["memory_id"]
+    meta = client.get(f"/v1/memory/{mid}").json()
+    # Default response shape unchanged; lifecycle fields are not in the
+    # default payload (queryable via the dedicated promotion endpoints).
+    assert "promotion_state" not in meta
+
+
+def test_existing_file_backed_workflow_compat(client: TestClient, fixture_file: Path):
+    """Adding a file-backed memory without lifecycle fields still works."""
+    resp = client.post(
+        "/v1/add",
+        json={
+            "identifier": "ds",
+            "file_uri": str(fixture_file),
+            "byte_offset": 0,
+            "byte_length": 20,
+            "source_format": "bin",
+        },
+    )
+    assert resp.status_code == 200
+    mid = resp.json()["memory_id"]
+    meta = client.get(f"/v1/memory/{mid}").json()
+    assert meta["memory_type"] == "file"
+
+
+def test_existing_jsonl_workflow_compat(client: TestClient, tmp_path: Path):
+    """Legacy JSONL snapshot hydrate still works without lifecycle fields."""
+    # Add a memory, snapshot to JSONL, then hydrate into the same DB.
+    client.post("/v1/add", json={"identifier": "a", "fact": "jsonl fact"})
+    swap = tmp_path / "swap.jsonl"
+    snap = client.post("/v1/snapshot", json={"path": str(swap)})
+    assert snap.status_code == 200
+    hyd = client.post("/v1/hydrate", json={"path": str(swap)})
+    assert hyd.status_code == 200
+    # The imported rows default to HOT/0 (the schema defaults), so promotion
+    # endpoints report the imported memories as HOT.
+    states = client.get("/v1/promotion/states").json()
+    assert "HOT" in states["states"]
+
+
+def test_existing_bundle_workflow_compat(tmp_path: Path):
+    """Bundle hydrate still works without lifecycle fields."""
+    from hotmem.bundle import MEMORY_MD
+    from hotmem.db import MemoryDB
+    from hotmem.snapshot import hydrate
+
+    bundle = tmp_path / "mybundle"
+    bundle.mkdir()
+    (bundle / MEMORY_MD).write_text("# Bundle\n\nFact: bundle fact\n")
+    db_path = tmp_path / "db.sqlite"
+    db = MemoryDB(db_path)
+    try:
+        result = hydrate(db, bundle)
+        assert result.loaded >= 1
+        rows = db.list_by_promotion_state("HOT")
+        assert len(rows) == result.loaded
+    finally:
+        db.close()
+
+
+# ── Candidate signal independence ─────────────────────────────────────────
+
+
+def test_candidate_independent_of_state(tmp_db: MemoryDB):
+    """The candidate flag can be set in any state and survives transitions."""
+    mid = _add_inline(tmp_db)
+    mark_candidate(tmp_db, mid, True, reason="hot lead")
+    assert tmp_db.get_memory(mid)["promotion_candidate"] == 1
+
+    transition(tmp_db, mid, "READY")
+    # Candidate flag persists across the transition.
+    assert tmp_db.get_memory(mid)["promotion_candidate"] == 1
+
+    mark_candidate(tmp_db, mid, False)
+    assert tmp_db.get_memory(mid)["promotion_candidate"] == 0
+
+
+def test_mark_candidate_missing_memory_raises(tmp_db: MemoryDB):
+    with pytest.raises(KeyError):
+        mark_candidate(tmp_db, "nope", True)
+
+
+def test_list_candidates_filters(tmp_db: MemoryDB):
+    blob = pack_embedding(embed_text("fact"))
+    tmp_db.insert(id="c1", identifier="x", fact_text="fact", embedding=blob, namespace="ns-a")
+    tmp_db.insert(id="c2", identifier="y", fact_text="fact", embedding=blob, namespace="ns-b")
+    tmp_db.insert(id="c3", identifier="z", fact_text="fact", embedding=blob, namespace="ns-a")
+    mark_candidate(tmp_db, "c1", True)
+    mark_candidate(tmp_db, "c2", True)
+    # c3 is not a candidate.
+
+    all_cands = list_candidates(tmp_db)
+    assert {r["id"] for r in all_cands} == {"c1", "c2"}
+
+    ns_a = list_candidates(tmp_db, namespace="ns-a")
+    assert [r["id"] for r in ns_a] == ["c1"]
+
+    # Transition c1 to READY; candidate flag survives, and state filter applies.
+    transition(tmp_db, "c1", "READY")
+    ready_cands = list_candidates(tmp_db, state="READY")
+    assert [r["id"] for r in ready_cands] == ["c1"]
+    hot_cands = list_candidates(tmp_db, state="HOT")
+    assert [r["id"] for r in hot_cands] == ["c2"]
+
+
+def test_list_by_state(tmp_db: MemoryDB):
+    blob = pack_embedding(embed_text("fact"))
+    tmp_db.insert(id="s1", identifier="x", fact_text="fact", embedding=blob)
+    tmp_db.insert(id="s2", identifier="y", fact_text="fact", embedding=blob)
+    transition(tmp_db, "s1", "READY")
+    hot = list_by_state(tmp_db, "HOT")
+    ready = list_by_state(tmp_db, "READY")
+    assert {r["id"] for r in hot} == {"s2"}
+    assert {r["id"] for r in ready} == {"s1"}
+
+
+# ── Event emission integration with #41 ──────────────────────────────────
+
+
+def test_transition_emits_promotion_event(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    transition(tmp_db, mid, "READY", reason="vetted", actor="analyst")
+
+    events = query_events(tmp_db, event_type=EventType.MEMORY_PROMOTION)
+    assert events["count"] == 1
+    ev = events["events"][0]
+    assert ev["memory_id"] == mid
+    assert ev["payload"]["from"] == "HOT"
+    assert ev["payload"]["to"] == "READY"
+    assert ev["payload"]["reason"] == "vetted"
+    assert ev["payload"]["actor"] == "analyst"
+
+
+def test_mark_candidate_emits_event(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    mark_candidate(tmp_db, mid, True, reason="strong lead")
+    events = query_events(tmp_db, event_type=EventType.MEMORY_CANDIDATE)
+    assert events["count"] == 1
+    ev = events["events"][0]
+    assert ev["memory_id"] == mid
+    assert ev["payload"]["candidate"] is True
+    assert ev["payload"]["reason"] == "strong lead"
+
+
+def test_transition_emit_event_false_suppresses(tmp_db: MemoryDB):
+    mid = _add_inline(tmp_db)
+    transition(tmp_db, mid, "READY", emit_event=False)
+    events = query_events(tmp_db, event_type=EventType.MEMORY_PROMOTION)
+    assert events["count"] == 0
+
+
+# ── Static states model ────────────────────────────────────────────────────
+
+
+def test_states_model():
+    model = states_model()
+    assert model["states"] == list(PROMOTION_STATES)
+    assert ["HOT", "READY"] in [list(t) for t in model["valid_transitions"]]
+    assert len(VALID_TRANSITIONS) == 3
+
+
+# ── API endpoints ─────────────────────────────────────────────────────────
+
+
+def test_api_promote_valid(client: TestClient):
+    mid = client.post("/v1/add", json={"identifier": "u", "fact": "x"}).json()["memory_id"]
+    resp = client.post(f"/v1/memory/{mid}/promote", json={"to_state": "READY"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"memory_id", "promotion_state", "updated_at", "trace_ms"}
+    assert body["promotion_state"] == "READY"
+
+
+def test_api_promote_invalid_returns_409_no_mutation(client: TestClient):
+    mid = client.post("/v1/add", json={"identifier": "u", "fact": "x"}).json()["memory_id"]
+    resp = client.post(f"/v1/memory/{mid}/promote", json={"to_state": "PROMOTED"})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"] == "invalid_transition"
+    assert body["from_state"] == "HOT"
+    assert body["to_state"] == "PROMOTED"
+    assert body["valid"] == ["READY"]
+    # State unchanged.
+    by_state = client.get("/v1/promotion/by-state", params={"state": "HOT"}).json()
+    assert any(c["memory_id"] == mid for c in by_state["memories"])
+
+
+def test_api_promote_missing_memory_returns_404(client: TestClient):
+    resp = client.post("/v1/memory/none/promote", json={"to_state": "READY"})
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "not_found"
+
+
+def test_api_candidate_set_and_clear(client: TestClient):
+    mid = client.post("/v1/add", json={"identifier": "u", "fact": "x"}).json()["memory_id"]
+    resp = client.post(f"/v1/memory/{mid}/candidate", json={"candidate": True})
+    assert resp.status_code == 200
+    assert resp.json()["promotion_candidate"] == 1
+    resp = client.post(f"/v1/memory/{mid}/candidate", json={"candidate": False})
+    assert resp.status_code == 200
+    assert resp.json()["promotion_candidate"] == 0
+
+
+def test_api_promotion_candidates(client: TestClient):
+    m1 = client.post("/v1/add", json={"identifier": "u1", "fact": "a"}).json()["memory_id"]
+    client.post("/v1/add", json={"identifier": "u2", "fact": "b"})
+    client.post(f"/v1/memory/{m1}/candidate", json={"candidate": True})
+    resp = client.get("/v1/promotion/candidates")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"candidates", "count", "trace_ms"}
+    assert body["count"] == 1
+    assert body["candidates"][0]["memory_id"] == m1
+
+
+def test_api_promotion_states(client: TestClient):
+    resp = client.get("/v1/promotion/states")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["states"] == ["HOT", "READY", "PROMOTED", "ARCHIVED"]
+    assert ["HOT", "READY"] in body["valid_transitions"]
+
+
+def test_api_promotion_by_state(client: TestClient):
+    m1 = client.post("/v1/add", json={"identifier": "u1", "fact": "a"}).json()["memory_id"]
+    client.post(f"/v1/memory/{m1}/promote", json={"to_state": "READY"})
+    resp = client.get("/v1/promotion/by-state", params={"state": "READY"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"memories", "count", "trace_ms"}
+    assert body["count"] == 1
+    assert body["memories"][0]["memory_id"] == m1
+    assert body["memories"][0]["promotion_state"] == "READY"
+
+
+def test_api_promote_emits_event(client: TestClient):
+    mid = client.post("/v1/add", json={"identifier": "u", "fact": "x"}).json()["memory_id"]
+    client.post(f"/v1/memory/{mid}/promote", json={"to_state": "READY"})
+    events = client.get("/v1/events", params={"event_type": EventType.MEMORY_PROMOTION}).json()
+    assert events["count"] == 1
+    assert events["events"][0]["memory_id"] == mid
+
+
+# ── API compatibility: existing endpoints unchanged when lifecycle omitted ──
+
+
+def test_api_search_shape_unchanged_without_lifecycle(client: TestClient):
+    client.post("/v1/add", json={"identifier": "u", "fact": "searchable fact"})
+    resp = client.post("/v1/search", json={"query": "searchable"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"memories", "count", "trace_ms"}
+
+
+def test_api_files_shape_unchanged(client: TestClient, fixture_file: Path):
+    resp = client.post(
+        "/v1/add",
+        json={
+            "identifier": "ds",
+            "file_uri": str(fixture_file),
+            "byte_offset": 0,
+            "byte_length": 10,
+            "source_format": "bin",
+        },
+    )
+    assert resp.status_code == 200
+    files = client.get("/v1/files").json()
+    assert set(files.keys()) == {"files", "count", "trace_ms"}
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+
+def test_cli_promote(tmp_path: Path):
+    from click.testing import CliRunner
+
+    from hotmem.cli import main
+
+    db_path = tmp_path / "db.sqlite"
+    # Seed a memory directly.
+    db = MemoryDB(db_path)
+    blob = pack_embedding(embed_text("a fact"))
+    db.insert(id="m1", identifier="u", fact_text="a fact", embedding=blob)
+    db.close()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["promote", "--db", str(db_path), "--memory-id", "m1", "--to", "READY"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "READY" in result.output
+
+    db = MemoryDB(db_path)
+    try:
+        assert db.get_memory("m1")["promotion_state"] == "READY"
+    finally:
+        db.close()
+
+
+def test_cli_promote_invalid_transition(tmp_path: Path):
+    from click.testing import CliRunner
+
+    from hotmem.cli import main
+
+    db_path = tmp_path / "db.sqlite"
+    db = MemoryDB(db_path)
+    blob = pack_embedding(embed_text("a fact"))
+    db.insert(id="m1", identifier="u", fact_text="a fact", embedding=blob)
+    db.close()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["promote", "--db", str(db_path), "--memory-id", "m1", "--to", "ARCHIVED"]
+    )
+    assert result.exit_code != 0
+    # State unchanged.
+    db = MemoryDB(db_path)
+    try:
+        assert db.get_memory("m1")["promotion_state"] == "HOT"
+    finally:
+        db.close()
+
+
+def test_cli_candidates(tmp_path: Path):
+    from click.testing import CliRunner
+
+    from hotmem.cli import main
+
+    db_path = tmp_path / "db.sqlite"
+    db = MemoryDB(db_path)
+    blob = pack_embedding(embed_text("a fact"))
+    db.insert(id="m1", identifier="u", fact_text="a fact", embedding=blob)
+    mark_candidate(db, "m1", True)
+    db.close()
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["candidates", "--db", str(db_path), "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert any(r["id"] == "m1" for r in data)


### PR DESCRIPTION
Closes #42. Builds on #41 (#64).

## Summary
Adds a local, explicit promotion state and promotion candidate signals without turning HotMem into a policy engine. HotMem stores state, transition metadata, and candidate signals, and emits promotion events through the #41 event log. EMOS owns policy — whether, when, and where promotion happens. No automatic remote migration, deletion, scheduling, approvals, or hierarchy protocol.

## State model
```
HOT -> READY -> PROMOTED -> ARCHIVED
```
Strict forward-only linear. Any other transition (including `ARCHIVED -> HOT` reheat and same-state "transitions") raises `InvalidTransitionError` and does not mutate state. EMOS may re-add a new memory at `HOT` if it needs to revive an archived one — HotMem will not rewind state on an existing record.

## Changes
- **`src/hotmem/lifecycle.py`**: `PROMOTION_STATES`, `VALID_TRANSITIONS` (strict forward-only), `InvalidTransitionError` (with `to_dict()` for 409 responses), `transition()`, `mark_candidate()`, `list_candidates()`, `list_by_state()`, `states_model()`. No policy, scheduling, approvals, or remote storage.
- **DB methods on `MemoryDB`**: `update_promotion_state`, `set_promotion_candidate`, `list_promotion_candidates`, `list_by_promotion_state`. Pure metadata writes — never touch backing files. No new columns (uses existing `promotion_state`/`promotion_candidate`/`updated_at` from the v2 migration).
- **API** (`src/hotmem/server.py`):
  - `POST /v1/memory/{id}/promote` — applies one validated transition; 409 `invalid_transition` without mutating state; 404 `not_found`.
  - `POST /v1/memory/{id}/candidate` — sets `promotion_candidate` independent of `promotion_state`; persists across transitions.
  - `GET /v1/promotion/candidates` — lightweight summaries (metadata only; no file hydration), optional `namespace`/`state` filters.
  - `GET /v1/promotion/by-state?state=READY&namespace=` — list memories in a given state.
  - `GET /v1/promotion/states` — static lifecycle model (`states` + `valid_transitions`).
- **CLI** (`src/hotmem/cli.py`): `hotmem promote --db PATH --memory-id ID --to STATE [--reason …] [--actor …]` and `hotmem candidates --db PATH [--json]`.
- **Event emission**: transitions emit `memory.promotion` (`{from, to, reason?, actor?}`); candidate changes emit `memory.candidate` (`{candidate, reason?}`). Visible at `GET /v1/events`. Suppressible via `emit_event=False` for batch callers.

## Compatibility guardrails (per issue)
- State and transition metadata persisted additively (no new columns; existing v2 fields reused).
- Valid transitions documented and enforced locally; invalid transitions return clear errors and do not mutate state.
- Promotion candidate/signal listable/queryable without requiring EMOS.
- Existing inline, file-backed, JSONL, and bundle memory workflows remain compatible; no caller must supply lifecycle fields (defaults `HOT`/`candidate=0`).
- No existing `/v1/*` default payload shape changes — lifecycle fields are not added to `GET /v1/memory/{id}` default response (queryable via the dedicated promotion endpoints).

## Tests (`tests/test_lifecycle.py`, 35 tests)
- Valid forward chain `HOT -> READY -> PROMOTED -> ARCHIVED` succeeds; state persisted; `updated_at` recorded.
- Invalid skip transition (`HOT -> PROMOTED`) raises `InvalidTransitionError`, `to_dict().valid == ["READY"]`, state unchanged.
- Invalid `ARCHIVED -> HOT` reheat rejected; state unchanged.
- Invalid same-state transition (`HOT -> HOT`) rejected.
- Unknown state raises `ValueError`; missing memory raises `KeyError`.
- Default-state backward compat: inline insert, file-backed insert, and a migrated pre-existing row all default to `HOT`/`candidate=0`.
- Workflow compat: inline, file-backed, JSONL hydrate, and bundle hydrate all work without lifecycle fields.
- Candidate independence: set in any state, persists across transitions, clearable.
- `list_candidates` filters by `namespace` and `state`; `list_by_state` returns memories per state.
- Event emission: `transition` emits `memory.promotion` with `{from, to, reason, actor}`; `mark_candidate` emits `memory.candidate`; `emit_event=False` suppresses.
- `states_model()` returns the static model.
- API: `/v1/memory/{id}/promote` valid + 409 + 404, `/v1/memory/{id}/candidate` set/clear, `/v1/promotion/candidates`, `/v1/promotion/states`, `/v1/promotion/by-state`, event emission through the API.
- API compat: `/v1/search` and `/v1/files` response shapes unchanged when lifecycle fields omitted.
- CLI: `hotmem promote` round-trip, invalid transition exits non-zero without mutation, `hotmem candidates --json` lists candidates.

## Verification
- `ruff check src/ tests/` — clean.
- `pytest` — 389 passed, 6 skipped (origin/main baseline + #41 + #42); all golden tests pass without modification.

## Definition of done (from issue)
- [x] State and transition metadata are persisted additively.
- [x] Valid transitions are documented and enforced locally.
- [x] Invalid transitions return clear errors and do not mutate state.
- [x] Promotion candidate/signal can be listed or queried without requiring EMOS.
- [x] Existing inline, file-backed, JSONL, and bundle memory workflows remain compatible.
- [x] Valid and invalid transition tests.
- [x] Default-state/backward-compatibility tests for existing records.
- [x] Event emission integration tests with #41.
- [x] API/CLI compatibility tests where lifecycle fields are omitted.