### PR TITLE
docs: set branded documentation URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to HotMem will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.2.3] - 2026-08-07
+
+### Changed
+- Documentation canonical URLs now use the branded `docs.knowguardai.com`
+  domain.
+- Package and runtime version metadata are aligned for automated PyPI release.
+
 ## [0.2.2] - 2026-07-16
 
 ### Added — Bundle store (#52, #50)

--- a/docs/hermes-v0.3-epic.md
+++ b/docs/hermes-v0.3-epic.md
@@ -93,7 +93,7 @@ Build `adapters/hermes-workspace/` that mirrors the agent adapter. Workspace is 
 #### Dependencies
 
 - Hermes Workspace MemoryProvider ABC (need to confirm interface matches Agent)
-- HotMem v0.2.2+ (current)
+- HotMem v0.2.3+ (current)
 
 #### Risks
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: HotMem
 site_description: Portable, local-first memory for AI agents and digital organizations
-site_url: https://knowguard-ai.github.io/HotMem
+site_url: https://docs.knowguardai.com/
 repo_url: https://github.com/KnowGuard-AI/HotMem
 repo_name: KnowGuard-AI/HotMem
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hotmem"
-version = "0.2.2"
+version = "0.2.3"
 description = "A local-first memory sidecar for agent applications"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hotmem/__init__.py
+++ b/src/hotmem/__init__.py
@@ -1,3 +1,3 @@
 """HotMem — A local-first memory sidecar for agent applications."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.3"

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "hotmem"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- set MkDocs canonical URL to https://docs.knowguardai.com/
- align generated canonical links and sitemap output with the configured HotMem Pages custom domain

## Validation

- uv run mkdocs build --strict

DNS and TLS must resolve before this is merged so the published canonical URL is reachable.